### PR TITLE
Add initial GitHub Actions for preview and staging

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,21 @@
+name: Deploy to Preview Channel
+
+on:
+  pull_request:
+
+jobs:
+  build_and_preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - run: yarn install
+      - run: yarn build
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_STAGING }}"
+          expires: 30d
+          projectId: atb-mobility-platform-staging

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,6 +13,8 @@ jobs:
           node-version: '12'
       - run: yarn install
       - run: yarn build
+        env:
+          WEBSHOP_BASE_URL: ${{ secrets.BASE_URL_STAGING }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -15,6 +15,8 @@ jobs:
           node-version: '12'
       - run: yarn install
       - run: yarn build
+        env:
+          WEBSHOP_BASE_URL: ${{ secrets.BASE_URL_STAGING }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,23 @@
+name: Deploy to Staging Channel
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy_live_website:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12'
+      - run: yarn install
+      - run: yarn build
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_STAGING }}"
+          projectId: atb-mobility-platform-staging
+          channelId: live

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ module.exports = {
 };
 ```
 
-It is highly recommended that you set the `host` property at least.
+The `baseUrl` needs to be set to be able to make calls to the backend.  As an
+alternative to using a local config file if you only need to set the base URL,
+you can set the `WEBSHOP_BASE_URL` environment variable.
 
 When making changes, always format Elm files using the following `elm-format` release:
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -162,7 +162,7 @@ function getBaseUrl(config, name) {
     // Use root of current server as default backend. This won't work for
     // development as the dev server only serves frontend code. It's just
     // a semi-sane default.
-    return '/';
+    return process.env.WEBSHOP_BASE_URL || '/';
 }
 
 // Get languageSwitcher from command line or config file


### PR DESCRIPTION
The preview channel is for creating a temporary deployment for each pull request that lives for 30 days.  Staging is for the permanent staging deployment.

Production deployments are not added yet as the backend isn't deployed and configurations are missing in the production environment.

Not sure how to test this properly, but all non-code configuration seems to be in order now.