### PR TITLE
fix: adds cache to gh actions to reduce yarn install time

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,23 +1,27 @@
 name: Deploy to Preview Channel
 
 on:
-  pull_request:
+    pull_request:
 
 jobs:
-  build_and_preview:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '12'
-      - run: yarn install
-      - run: yarn build
-        env:
-          WEBSHOP_BASE_URL: ${{ secrets.BASE_URL_STAGING }}
-      - uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_STAGING }}"
-          expires: 30d
-          projectId: atb-mobility-platform-staging
+    build_and_preview:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/cache@v2
+              with:
+                  path: '**/node_modules'
+                  key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: '12'
+            - run: yarn install
+            - run: yarn build
+              env:
+                  WEBSHOP_BASE_URL: ${{ secrets.BASE_URL_STAGING }}
+            - uses: FirebaseExtended/action-hosting-deploy@v0
+              with:
+                  repoToken: '${{ secrets.GITHUB_TOKEN }}'
+                  firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_STAGING }}'
+                  expires: 30d
+                  projectId: atb-mobility-platform-staging

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,25 +1,29 @@
 name: Deploy to Staging Channel
 
 on:
-  push:
-    branches:
-      - master
+    push:
+        branches:
+            - master
 
 jobs:
-  deploy_live_website:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '12'
-      - run: yarn install
-      - run: yarn build
-        env:
-          WEBSHOP_BASE_URL: ${{ secrets.BASE_URL_STAGING }}
-      - uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_STAGING }}"
-          projectId: atb-mobility-platform-staging
-          channelId: live
+    deploy_live_website:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/cache@v2
+              with:
+                  path: '**/node_modules'
+                  key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+            - uses: actions/setup-node@v2
+              with:
+                  node-version: '12'
+            - run: yarn install
+            - run: yarn build
+              env:
+                  WEBSHOP_BASE_URL: ${{ secrets.BASE_URL_STAGING }}
+            - uses: FirebaseExtended/action-hosting-deploy@v0
+              with:
+                  repoToken: '${{ secrets.GITHUB_TOKEN }}'
+                  firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_STAGING }}'
+                  projectId: atb-mobility-platform-staging
+                  channelId: live


### PR DESCRIPTION
Dette vil ganske drastisk forbedre byggetid som er litt viktig når vi har kontinuerlig previews her slik at det er enklere å dele lenker med en gang. 