### PR TITLE
fix: only show fare products of right type

### DIFF
--- a/src/elm/Data/RefData.elm
+++ b/src/elm/Data/RefData.elm
@@ -22,6 +22,7 @@ type alias FareProduct =
     , name : LangString
     , description : LangString
     , alternativeNames : List LangString
+    , limitations : List String
     }
 
 

--- a/src/elm/Data/RefData.elm
+++ b/src/elm/Data/RefData.elm
@@ -1,6 +1,7 @@
 module Data.RefData exposing
     ( FareProduct
     , LangString(..)
+    , Limitation
     , TariffZone
     , UserProfile
     , UserType(..)
@@ -23,6 +24,12 @@ type alias FareProduct =
     , description : LangString
     , alternativeNames : List LangString
     , limitations : List String
+    }
+
+
+type alias Limitation =
+    { productId : String
+    , limitations : List UserType
     }
 
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -288,7 +288,7 @@ update msg model =
         ShopMsg subMsg ->
             case model.shop of
                 Just shop ->
-                    ShopPage.update subMsg model.environment shop
+                    ShopPage.update subMsg model.environment shop model.shared
                         |> PageUpdater.map (\newModel -> { model | shop = Just newModel }) ShopMsg
                         |> doPageUpdate
 

--- a/src/elm/Notification.elm
+++ b/src/elm/Notification.elm
@@ -11,6 +11,7 @@ module Notification exposing
 -}
 
 import Html as H exposing (Html)
+import Util.Func as Func
 
 
 {-| Describes a notification.
@@ -56,7 +57,7 @@ setTimer timer confirm =
 -}
 decrementTimer : Notification msg -> Notification msg
 decrementTimer confirm =
-    { confirm | timer = confirm.timer |> Maybe.map (flip (-) 1) }
+    { confirm | timer = confirm.timer |> Maybe.map (Func.flip (-) 1) }
 
 
 {-| Maps a function over `Notification`
@@ -66,8 +67,3 @@ map f notification =
     { content = H.map f notification.content
     , timer = notification.timer
     }
-
-
-flip : (a -> b -> c) -> b -> a -> c
-flip f a b =
-    f b a

--- a/src/elm/Service/RefData.elm
+++ b/src/elm/Service/RefData.elm
@@ -54,6 +54,7 @@ fareProductDecoder =
         |> DecodeP.required "name" langStringDecoder
         |> DecodeP.optional "description" langStringDecoder (LangString "" "")
         |> DecodeP.required "alternativeNames" (Decode.list langStringDecoder)
+        |> DecodeP.required "limitations" limitationsDecoder
 
 
 userProfileDecoder : Decoder UserProfile
@@ -76,6 +77,12 @@ langStringDecoder =
     Decode.succeed LangString
         |> DecodeP.optional "lang" Decode.string ""
         |> DecodeP.optional "value" Decode.string ""
+
+
+limitationsDecoder : Decoder (List String)
+limitationsDecoder =
+    Decode.succeed identity
+        |> DecodeP.required "userProfileRefs" (Decode.list Decode.string)
 
 
 userTypeDecoder : Decoder UserType

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -1,6 +1,8 @@
 module Shared exposing (Msg, Shared, init, subscriptions, update)
 
-import Data.RefData exposing (FareProduct, TariffZone, UserProfile)
+import Data.RefData exposing (FareProduct, Limitation, TariffZone, UserProfile, UserType)
+import List exposing (product)
+import List.Extra
 import Service.RefData as RefDataService
 
 
@@ -14,6 +16,7 @@ type alias Shared =
     { tariffZones : List TariffZone
     , fareProducts : List FareProduct
     , userProfiles : List UserProfile
+    , productLimitations : List Limitation
     }
 
 
@@ -22,6 +25,7 @@ init =
     { tariffZones = []
     , fareProducts = []
     , userProfiles = []
+    , productLimitations = []
     }
 
 
@@ -39,7 +43,10 @@ update msg model =
         ReceiveFareProducts result ->
             case result of
                 Ok value ->
-                    { model | fareProducts = value }
+                    { model
+                        | fareProducts = value
+                        , productLimitations = getMappedLimitations value model.userProfiles
+                    }
 
                 Err _ ->
                     model
@@ -47,10 +54,33 @@ update msg model =
         ReceiveUserProfiles result ->
             case result of
                 Ok value ->
-                    { model | userProfiles = value }
+                    { model
+                        | userProfiles = value
+                        , productLimitations = getMappedLimitations model.fareProducts value
+                    }
 
                 Err _ ->
                     model
+
+
+
+-- Fare products.limitations -> map to userTypes
+
+
+getMappedLimitations : List FareProduct -> List UserProfile -> List Limitation
+getMappedLimitations products userProfiles =
+    let
+        userIdToType : String -> Maybe UserType
+        userIdToType id =
+            userProfiles |> List.Extra.find (.id >> (==) id) |> Maybe.map .userType
+    in
+        products
+            |> List.map
+                (\product ->
+                    { productId = product.id
+                    , limitations = product.limitations |> List.filterMap userIdToType
+                    }
+                )
 
 
 subscriptions : Sub Msg

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -63,10 +63,6 @@ update msg model =
                     model
 
 
-
--- Fare products.limitations -> map to userTypes
-
-
 getMappedLimitations : List FareProduct -> List UserProfile -> List Limitation
 getMappedLimitations products userProfiles =
     let
@@ -78,7 +74,7 @@ getMappedLimitations products userProfiles =
             |> List.map
                 (\product ->
                     { productId = product.id
-                    , limitations = product.limitations |> List.filterMap userIdToType
+                    , limitations = List.filterMap userIdToType product.limitations
                     }
                 )
 

--- a/src/elm/Util/Func.elm
+++ b/src/elm/Util/Func.elm
@@ -1,0 +1,6 @@
+module Util.Func exposing (flip)
+
+
+flip : (a -> b -> c) -> b -> a -> c
+flip f a b =
+    f b a


### PR DESCRIPTION
Litt knot dette. Men i FareContracts i RemoteConfig så ligger det en oversikt over hvilke UserTypes som er gjeldene for hver. Her lager jeg en liste med gyldige begrensninger og lager en mappen fra og tilbake fra produkter. For at dette skal være mest naturlig endrer jeg også rekkefølge på billettype.

Men det kan være tilfeller hvor man velger F.eks Enkeltbillett, så Ungdom og deretter Periode-billett. I disse tilfellene resetter jeg bare tilstand til å ha voksen som valgt kategori. Kan være vi på et tidspunkt skal heller legge inn en validering eller noe, da det kan være litt misvisende og overraskende.

<img width="975" alt="Screenshot 2021-04-22 at 19 28 23" src="https://user-images.githubusercontent.com/606374/115759852-02fb0700-a3a1-11eb-8721-787a47ccc742.png">

<img width="965" alt="Screenshot 2021-04-22 at 19 28 31" src="https://user-images.githubusercontent.com/606374/115759842-01314380-a3a1-11eb-83d7-d1a12f1d90ae.png">
