### PR TITLE
fix: dont show error when logging out normally

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -123,6 +123,10 @@ app.ports.signOutHandler.subscribe(async () => {
     clearRefreshToken();
 
     try {
+        // Remove loggedIn before signing out to avoid showing error
+        // below on onAuthStateChanged.
+        localStorage.removeItem('loggedIn');
+
         await firebase.auth().signOut();
 
         unsubscribeFareContractSnapshot && unsubscribeFareContractSnapshot();
@@ -132,8 +136,6 @@ app.ports.signOutHandler.subscribe(async () => {
         unsubscribeFetchUserDataSnapshot = null;
     } catch (e) {
         console.error('[debug] Unable to logout: ', e);
-    } finally {
-        localStorage.removeItem('loggedIn');
     }
 });
 
@@ -152,7 +154,7 @@ firebase.auth().onAuthStateChanged((user) => {
 
         app.ports.signInError.send({
             code: -1,
-            message: 'Du er blitt logget ut. Logg inn igjen.'
+            message: 'Du er blitt logget ut.'
         });
     }
 });


### PR DESCRIPTION
Fikser feil hvor det kommer feilmelding ved normal utlogging. Denne feilmeldingen burde kun dukke opp når det er en feil hvor loggedIn i localStorage er aktiv selv om firebase sier noe annet (for å unngå tidligere evig loading screen).