### PR TITLE
fix: border radius for radio inputs

### DIFF
--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -233,11 +233,13 @@
     background: var(--colors-background_0-backgroundColor);
     color: var(--colors-background_0-color);
 
-    border-radius: var(--border-radius-regular);
-
     border: var(--border-width-medium) solid transparent;
     // Remove border from padding.
     padding: calc(var(--spacings-xLarge) - 2 * var(--border-width-medium));
+}
+.ui-input-radioGroup .ui-group__item:last-of-type .ui-input-radio {
+    border-bottom-left-radius: var(--border-radius-regular);
+    border-bottom-right-radius: var(--border-radius-regular);
 }
 .ui-input-radio:hover {
     background: var(--colors-background_2-backgroundColor);
@@ -445,13 +447,10 @@
 
 .ui-input-text {
     transition: all 150ms ease-in-out;
-    border-radius: var(--border-radius-regular);
     border: var(--border-width-medium) solid transparent;
 
     // Remove border from padding.
-    padding: calc(var(--spacings-medium) - var(--border-width-medium));
-    margin: var(--spacings-medium)
-        calc(var(--spacings-medium) - var(--border-width-medium));
+    padding: calc(var(--spacings-xLarge) - var(--border-width-medium));
 
     transition: all 150ms ease-in-out;
 
@@ -480,7 +479,6 @@
 }
 .ui-input-text:focus-within {
     border-color: var(--colors-primary_2-backgroundColor);
-    border-radius: var(--border-radius-regular);
 }
 .ui-input-text__label {
     margin-bottom: var(--spacings-medium);


### PR DESCRIPTION
Endrer input (text og radio) til nytt design med ikke border-radius for elementer som er "mid-section".

## Eksempler

<img width="1009" alt="Screenshot 2021-04-29 at 22 12 38" src="https://user-images.githubusercontent.com/606374/116612761-33f6b100-a938-11eb-8cbc-a3519504da5a.png">

<img width="573" alt="Screenshot 2021-04-29 at 22 12 52" src="https://user-images.githubusercontent.com/606374/116612754-335e1a80-a938-11eb-9e90-9972cb2a6cb6.png">
<img width="1016" alt="Screenshot 2021-04-29 at 22 12 43" src="https://user-images.githubusercontent.com/606374/116612756-335e1a80-a938-11eb-9181-fe34089fa020.png">

<img width="644" alt="Screenshot 2021-04-29 at 22 12 54" src="https://user-images.githubusercontent.com/606374/116612750-322ced80-a938-11eb-825a-60e053c735ac.png">
