### PR TITLE
fix: transition for input texts

### DIFF
--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -450,13 +450,11 @@
 }
 
 .ui-input-text {
-    transition: all 150ms ease-in-out;
+    transition: border 150ms ease-in-out, background 100ms ease;
     border: var(--border-width-medium) solid transparent;
 
     // Remove border from padding.
     padding: calc(var(--spacings-xLarge) - var(--border-width-medium));
-
-    transition: all 150ms ease-in-out;
 
     svg,
     path {


### PR DESCRIPTION
Unngår bevegelse i elementet ved lasting av side eller nye elementer. Kun gjør overganganimasjon på border.