### PR TITLE
feat: adds "thanks" page as redirect target after Vipps payment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,32 +20,13 @@ Once your environment is up and running, start the dev server:
 $ yarn start
 ```
 
-<<<<<<< HEAD
 By default, this will launch a development server at http://127.0.0.1:8000/ but
 this can be configured (see Configuration below)
-=======
-This will launch a server at http://127.0.0.1:8000/ but this can be
-configured in your `webpack.local.config.js` file. Simply add
-something like this to that file if it doesn't exist:
->>>>>>> a46e40b (docs: adds notice on ticketing testing)
 
 When making changes, always format Elm files using the following `elm-format`
 release:
 
-<<<<<<< HEAD
 > https://github.com/mjenssen/elm-format/releases/latest
-=======
-The `baseUrl` needs to be set to be able to make calls to the backend. As an
-alternative to using a local config file, you can set the `WEBSHOP_BASE_URL`
-environment variable.
-
-The `firebaseConfig` needs to be set to be able to connect to Firebase. As an
-alternative to using a local config file, you can also set the
-`WEBSHOP_FIREBASE_CONFIG` environment variable. The config needs to be valid
-JSON, so remember when copying the config from the Firebase console to change
-the keys to be double-quoted strings (this is only necessary when using an
-environment variable).
->>>>>>> a46e40b (docs: adds notice on ticketing testing)
 
 It can also be installed with `yarn`:
 
@@ -67,30 +48,29 @@ To build for production, just run the `build` script:
 $ yarn build
 ```
 
-<<<<<<< HEAD
 You will need to configure base URL and Firebase config (see Configuration
 below).
 
 This will create a `dist` folder with everything, including compressed versions
-of all files that are at least 1024 bytes in size.  There are two compressed
-files per original file: a zopfli (.gz) file and a brotli (.br) file.  If a file
+of all files that are at least 1024 bytes in size. There are two compressed
+files per original file: a zopfli (.gz) file and a brotli (.br) file. If a file
 doesn't compress well, there won't be a compressed version of it.
 
 ## Configuration
 
-There are two ways to configure the environment.  For basic configuration, you
+There are two ways to configure the environment. For basic configuration, you
 can use environment variables:
 
-- `WEBSHOP_BASE_URL`: The base URL to the backend.
-- `WEBSHOP_FIREBASE_CONFIG`: The Firebase config.  The config needs to be valid
-  JSON, so remember when copying the config from the Firebase console to change
-  the keys to be double-quoted strings (this is only necessary when using an
-  environment variable).
+-   `WEBSHOP_BASE_URL`: The base URL to the backend.
+-   `WEBSHOP_FIREBASE_CONFIG`: The Firebase config. The config needs to be valid
+    JSON, so remember when copying the config from the Firebase console to change
+    the keys to be double-quoted strings (this is only necessary when using an
+    environment variable).
 
 There is also support for using a `.env` file containing these variables.
 
 For more advanced configuration needs, you can use a local webpack config file,
-named `webpack.local.config.js`.  This is a normal JavaScript file so you can do
+named `webpack.local.config.js`. This is a normal JavaScript file so you can do
 anything you want here, like importing other modules or using code to create the
 configuration.
 
@@ -105,20 +85,13 @@ module.exports = {
 };
 ```
 
-- `host`: The hostname or IP address the development server will listen on.
-- `port`: The port the development server will listen on.
-- `baseUrl`: The base URL to the backend.
-- `firebaseConfig`: The Firebase config.  Unlike environment variables, you can
-  just copy the value from the Firebase console.
-- `proxy` (optional): This can be set to configure Webpack's proxy system.  Only
-  relevant when running the development server.
-=======
-This will create a `dist` folder with everything, including compressed
-versions of all files that are at least 1024 bytes in size. There are
-two compressed files per original file: a zopfli (.gz) file and a
-brotli (.br) file. If a file doesn't compress well, there won't be a
-compressed version of it.
->>>>>>> a46e40b (docs: adds notice on ticketing testing)
+-   `host`: The hostname or IP address the development server will listen on.
+-   `port`: The port the development server will listen on.
+-   `baseUrl`: The base URL to the backend.
+-   `firebaseConfig`: The Firebase config. Unlike environment variables, you can
+    just copy the value from the Firebase console.
+-   `proxy` (optional): This can be set to configure Webpack's proxy system. Only
+    relevant when running the development server.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AtB Webshop
 
-The frontend is written in Elm.  It currently uses Elm 0.19.1.
+The frontend is written in Elm. It currently uses Elm 0.19.1.
 
 ## Setting up the environment
 
@@ -20,13 +20,32 @@ Once your environment is up and running, start the dev server:
 $ yarn start
 ```
 
+<<<<<<< HEAD
 By default, this will launch a development server at http://127.0.0.1:8000/ but
 this can be configured (see Configuration below)
+=======
+This will launch a server at http://127.0.0.1:8000/ but this can be
+configured in your `webpack.local.config.js` file. Simply add
+something like this to that file if it doesn't exist:
+>>>>>>> a46e40b (docs: adds notice on ticketing testing)
 
 When making changes, always format Elm files using the following `elm-format`
 release:
 
+<<<<<<< HEAD
 > https://github.com/mjenssen/elm-format/releases/latest
+=======
+The `baseUrl` needs to be set to be able to make calls to the backend. As an
+alternative to using a local config file, you can set the `WEBSHOP_BASE_URL`
+environment variable.
+
+The `firebaseConfig` needs to be set to be able to connect to Firebase. As an
+alternative to using a local config file, you can also set the
+`WEBSHOP_FIREBASE_CONFIG` environment variable. The config needs to be valid
+JSON, so remember when copying the config from the Firebase console to change
+the keys to be double-quoted strings (this is only necessary when using an
+environment variable).
+>>>>>>> a46e40b (docs: adds notice on ticketing testing)
 
 It can also be installed with `yarn`:
 
@@ -36,6 +55,10 @@ $ yarn global add @atb-as/elm-format
 
 This is to ensure that `let-in` expressions are correctly indented.
 
+### Testing ticketing
+
+[See docs at App](https://github.com/AtB-AS/mittatb-app/blob/master/docs/TicketingQA.md)
+
 ## Production
 
 To build for production, just run the `build` script:
@@ -44,6 +67,7 @@ To build for production, just run the `build` script:
 $ yarn build
 ```
 
+<<<<<<< HEAD
 You will need to configure base URL and Firebase config (see Configuration
 below).
 
@@ -88,6 +112,13 @@ module.exports = {
   just copy the value from the Firebase console.
 - `proxy` (optional): This can be set to configure Webpack's proxy system.  Only
   relevant when running the development server.
+=======
+This will create a `dist` folder with everything, including compressed
+versions of all files that are at least 1024 bytes in size. There are
+two compressed files per original file: a zopfli (.gz) file and a
+brotli (.br) file. If a file doesn't compress well, there won't be a
+compressed version of it.
+>>>>>>> a46e40b (docs: adds notice on ticketing testing)
 
 ## License
 

--- a/firebase.json
+++ b/firebase.json
@@ -1,46 +1,45 @@
 {
-  "hosting": {
-    "target": "webshop",
-    "public": "dist",
-    "rewrites": [
-    ],
-    "headers": [
-      {
-        "source": "/service-worker.js",
+    "hosting": {
+        "target": "webshop",
+        "public": "dist",
+        "rewrites": [{ "source": "**", "destination": "/index.html" }],
         "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "max-age=0"
-          }
+            {
+                "source": "/service-worker.js",
+                "headers": [
+                    {
+                        "key": "Cache-Control",
+                        "value": "max-age=0"
+                    }
+                ]
+            },
+            {
+                "source": "/",
+                "headers": [
+                    {
+                        "key": "Cache-Control",
+                        "value": "max-age=0"
+                    }
+                ]
+            },
+            {
+                "source": "**/api/**",
+                "headers": [
+                    {
+                        "key": "Cache-Control",
+                        "value": "no-cache, no-store, must-revalidate"
+                    }
+                ]
+            },
+            {
+                "source": "**/*.@(css|js)",
+                "headers": [
+                    {
+                        "key": "Cache-Control",
+                        "value": "max-age=604800"
+                    }
+                ]
+            }
         ]
-      },
-      {
-        "source": "/",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "max-age=0"
-          }
-        ]
-      },
-      {
-        "source": "**/api/**",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "no-cache, no-store, must-revalidate"
-          }
-        ]
-      },
-      {
-        "source": "**/*.@(css|js)",
-        "headers": [
-          {
-            "key": "Cache-Control",
-            "value": "max-age=604800"
-          }
-        ]
-      }
-    ]
-  }
+    }
 }

--- a/src/elm/Environment.elm
+++ b/src/elm/Environment.elm
@@ -19,6 +19,7 @@ type DistributionEnvironment
 
 type alias Environment =
     { distributionEnv : DistributionEnvironment
+    , localUrl : String
     , baseUrl : String
     , ticketUrl : String
     , refDataUrl : String

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -451,15 +451,15 @@ header model =
             , ( "Min profil", Route.Settings )
             ]
 
-        isLoggedIn =
-            model.environment.customerId /= Nothing
+        showHeader =
+            model.environment.customerId /= Nothing && model.route /= Just Route.Thanks
     in
         H.header [ A.class "pageHeader" ]
             [ H.div [ A.class "pageHeader__content" ]
                 [ H.h1 [ A.class "pageHeader__logo" ]
                     [ H.a [ Route.href Route.Home ] [ Icon.atb, H.text "AtB Nettbutikk" ]
                     ]
-                , if isLoggedIn then
+                , if showHeader then
                     H.nav [ A.class "pageHeader__nav" ]
                         [ H.ul []
                             (List.map
@@ -546,6 +546,9 @@ viewPage model =
                     |> H.map AccountMsg
                     |> wrapSubPage "Kontoinformasjon"
 
+            Just Route.Thanks ->
+                viewSuccessTicketPage
+
             _ ->
                 OverviewPage.view env model.appInfo shared model.overview model.route
                     |> H.map OverviewMsg
@@ -556,6 +559,14 @@ wrapSubPage title children =
     H.div []
         [ PH.init |> PH.setTitle (Just title) |> PH.setBackRoute ( Route.Home, "Oversikt" ) |> PH.view
         , children
+        ]
+
+
+viewSuccessTicketPage : Html msg
+viewSuccessTicketPage =
+    H.div [ A.class "pageHome__successBuy" ]
+        [ H.img [ A.src "/images/empty-illustration.svg" ] []
+        , H.p [] [ H.text "Takk! Du kan nå lukke vinduet." ]
         ]
 
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -79,6 +79,7 @@ type alias Model =
 
 type alias Flags =
     { isDevelopment : Bool
+    , localUrl : String
     , baseUrl : String
     , ticketUrl : String
     , refDataUrl : String
@@ -133,6 +134,7 @@ init flags url navKey =
         environment : Environment
         environment =
             { distributionEnv = distributionEnv
+            , localUrl = flags.localUrl
             , baseUrl = flags.baseUrl
             , ticketUrl = flags.ticketUrl
             , refDataUrl = flags.refDataUrl
@@ -524,10 +526,6 @@ viewPage model =
             model.shared
     in
         case model.route of
-            Just Route.Home ->
-                OverviewPage.view env model.appInfo shared model.overview model.route
-                    |> H.map OverviewMsg
-
             Just Route.Shop ->
                 case model.shop of
                     Just shop ->
@@ -548,24 +546,9 @@ viewPage model =
                     |> H.map AccountMsg
                     |> wrapSubPage "Kontoinformasjon"
 
-            Just Route.NotFound ->
-                H.div
-                    [ A.class "welcome-container" ]
-                    [ H.div []
-                        [ H.h2 [] [ H.text model.appInfo.title ]
-                        , H.h3 [] [ H.text "Not found." ]
-                        ]
-                    ]
-
-            Nothing ->
-                H.div
-                    [ A.class "welcome-container" ]
-                    [ H.div []
-                        [ H.h2 [] [ H.text model.appInfo.title ]
-                        , H.h3 [] [ H.a [ A.href "#/" ] [ H.text "Go home" ] ]
-                        , H.h3 [] [ H.a [ A.href "#/settings" ] [ H.text "Go to settings" ] ]
-                        ]
-                    ]
+            _ ->
+                OverviewPage.view env model.appInfo shared model.overview model.route
+                    |> H.map OverviewMsg
 
 
 wrapSubPage : String -> Html msg -> Html msg

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -280,6 +280,7 @@ update msg env model shared =
                             "CAPTURE" ->
                                 PageUpdater.init { model | reservation = NotLoaded, offers = NotLoaded }
                                     |> PageUpdater.addGlobalAction (GA.SetPendingOrder orderId)
+                                    |> addGlobalNotification (Message.Valid "Ny billett lagt til.")
                                     |> PageUpdater.addGlobalAction GA.CloseShop
 
                             "CANCEL" ->

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -417,19 +417,29 @@ richActionButton active maybeAction content =
 view : Environment -> AppInfo -> Shared -> Model -> Maybe Route -> Html Msg
 view _ _ shared model _ =
     let
-        disableButtons =
-            case model.reservation of
-                Loading _ ->
-                    True
-
-                Loaded _ ->
-                    True
-
-                _ ->
-                    False
-
         summary =
             modelSummary shared model
+
+        errorMessage =
+            case model.offers of
+                Failed message ->
+                    Just message
+
+                _ ->
+                    Nothing
+
+        disableButtons =
+            (errorMessage /= Nothing)
+                || (case model.reservation of
+                        Loading _ ->
+                            True
+
+                        Loaded _ ->
+                            True
+
+                        _ ->
+                            False
+                   )
     in
         H.div [ A.class "page" ]
             [ H.div []
@@ -492,7 +502,8 @@ view _ _ shared model _ =
                 , Section.init
                     |> Section.setMarginBottom True
                     |> Section.viewWithOptions
-                        [ B.init "Kjøp med bankkort"
+                        [ Html.Extra.viewMaybe Message.error errorMessage
+                        , B.init "Kjøp med bankkort"
                             |> B.setDisabled disableButtons
                             |> B.setIcon (Just Icon.creditcard)
                             |> B.setOnClick (Just (BuyOffers Nets))

--- a/src/elm/Route.elm
+++ b/src/elm/Route.elm
@@ -52,7 +52,7 @@ routeToString page =
                 NotFound ->
                     [ "not-found" ]
     in
-        "#/" ++ String.join "/" pieces
+        "/" ++ String.join "/" pieces
 
 
 
@@ -76,11 +76,7 @@ newUrl key route =
 
 fromUrl : Url -> Maybe Route
 fromUrl url =
-    Maybe.andThen
-        (\fragment ->
-            { url | path = fragment, fragment = Nothing }
-                |> Parser.parse parser
-                |> Maybe.withDefault NotFound
-                |> Just
-        )
-        url.fragment
+    url
+        |> Parser.parse parser
+        |> Maybe.withDefault NotFound
+        |> Just

--- a/src/elm/Route.elm
+++ b/src/elm/Route.elm
@@ -17,6 +17,7 @@ import Url.Parser as Parser exposing ((</>), Parser, oneOf, s)
 type Route
     = Home
     | Shop
+    | Thanks
     | History
     | Settings
     | NotFound
@@ -28,6 +29,7 @@ parser =
         [ Parser.map Home Parser.top
         , Parser.map Shop <| s "shop"
         , Parser.map History <| s "history"
+        , Parser.map Thanks <| s "thanks"
         , Parser.map Settings <| s "settings"
         ]
 
@@ -42,6 +44,9 @@ routeToString page =
 
                 Shop ->
                     [ "shop" ]
+
+                Thanks ->
+                    [ "thanks" ]
 
                 History ->
                     [ "history" ]

--- a/src/elm/Service/Misc.elm
+++ b/src/elm/Service/Misc.elm
@@ -3,6 +3,7 @@ port module Service.Misc exposing
     , convertTime
     , convertedTime
     , fareContractDecoder
+    , navigateTo
     , onProfileChange
     , onboardingDone
     , onboardingStart
@@ -19,6 +20,9 @@ import Json.Encode as Encode
 
 
 port openWindow : String -> Cmd msg
+
+
+port navigateTo : String -> Cmd msg
 
 
 port receiveTokens : (Encode.Value -> msg) -> Sub msg

--- a/src/elm/Service/Misc.elm
+++ b/src/elm/Service/Misc.elm
@@ -3,7 +3,6 @@ port module Service.Misc exposing
     , convertTime
     , convertedTime
     , fareContractDecoder
-    , navigateTo
     , onProfileChange
     , onboardingDone
     , onboardingStart
@@ -20,9 +19,6 @@ import Json.Encode as Encode
 
 
 port openWindow : String -> Cmd msg
-
-
-port navigateTo : String -> Cmd msg
 
 
 port receiveTokens : (Encode.Value -> msg) -> Sub msg

--- a/src/elm/Service/Ticket.elm
+++ b/src/elm/Service/Ticket.elm
@@ -54,7 +54,7 @@ reserve env paymentType offers =
             Encode.object
                 [ ( "offers", Encode.list encodeOffer offers )
                 , ( "payment_type", encodePaymentType paymentType )
-                , ( "payment_redirect_url", Encode.string (env.ticketUrl ++ "/thanks") )
+                , ( "payment_redirect_url", Encode.string (env.localUrl ++ "/thanks") )
                 ]
     in
         HttpUtil.post env url (Http.jsonBody body) (Http.expectJson reservationDecoder)

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -43,7 +43,8 @@ const app = Elm.Main.init({
     flags: Object.assign(
         {
             installId: installId,
-            loggedIn: localStorage['loggedIn'] === 'loggedIn'
+            loggedIn: localStorage['loggedIn'] === 'loggedIn',
+            localUrl: window.location.origin
         },
         elmFlags
     )
@@ -341,6 +342,10 @@ app.ports.onboardingDone.subscribe(() => {
 
 app.ports.openWindow.subscribe((url) => {
     window.open(url);
+});
+
+app.ports.navigateTo.subscribe((url) => {
+    window.location.assign(url);
 });
 
 if (app.ports.convertTime) {

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -344,10 +344,6 @@ app.ports.openWindow.subscribe((url) => {
     window.open(url);
 });
 
-app.ports.navigateTo.subscribe((url) => {
-    window.location.assign(url);
-});
-
 if (app.ports.convertTime) {
     app.ports.convertTime.subscribe(([date, time]) => {
         try {

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -351,6 +351,15 @@ p {
     max-width: 100%;
 }
 
+.pageHome__successBuy {
+    text-align: center;
+
+    img {
+        display: block;
+        margin: 0 auto;
+    }
+}
+
 // Components
 
 .toggle {


### PR DESCRIPTION
Dette legger til en enkel (midlertidig) side for mottak av betaling via Vipps. Dette for å gi noe mer kontekst etter endt betaling eller avbrutt betaling i Vipps. Dette er ikke optimalt, men for at det skal være litt bedre trengs det mye mer omskriving og noen kode-konseptuelle endringer. Se #107 og #105 for kontekst.

For å få til dette må det gjøres om til å ikke bruke skigard-tegn i URL. Men det er uansett en fordel og modernisering av gammel måte å håndtere "SPA routing" på. 


TODO:

Trenger copy på meldinger. Helt konkret melding som kommer opp som boks når man har fått kjøpt billett.