### PR TITLE
feat: adds warning on missing email for receipt

### DIFF
--- a/src/elm/Page/History.elm
+++ b/src/elm/Page/History.elm
@@ -20,6 +20,7 @@ import Shared exposing (Shared)
 import Task
 import Ui.Button as B
 import Ui.Group
+import Ui.Input.Text as T
 import Ui.Message
 import Ui.Section
 import Util.Format as Format
@@ -118,24 +119,34 @@ update msg env model =
 
 view : Environment -> AppInfo -> Shared -> Model -> Maybe Route -> Html Msg
 view _ _ shared model _ =
-    H.div [ A.class "page-history" ]
-        [ H.div [ A.class "sidebar" ] [ viewSidebar model ]
-        , H.div [ A.class "main" ] [ viewMain shared model ]
+    H.div [ A.class "page page--history" ]
+        [ viewSidebar model
+        , viewMain shared model
         ]
 
 
 viewSidebar : Model -> Html Msg
 viewSidebar model =
-    H.div [ A.class "section-box" ]
-        [ H.div [ A.class "section-header" ] [ H.text "Filtrer på dato" ]
-        , textInput (Maybe.withDefault "" model.from)
-            InputFrom
-            "Fra"
-            "Velg dato"
-        , textInput (Maybe.withDefault "" model.to)
-            InputTo
-            "Til"
-            "Velg dato"
+    Ui.Section.view
+        [ Ui.Section.viewHeader "Filtrer på dato"
+        , Ui.Section.viewItem
+            [ T.init "from"
+                |> T.setValue model.from
+                |> T.setOnInput (Just InputFrom)
+                |> T.setType "date"
+                |> T.setPlaceholder "Velg dato"
+                |> T.setTitle (Just "Fra")
+                |> T.view
+            ]
+        , Ui.Section.viewItem
+            [ T.init "to"
+                |> T.setValue model.to
+                |> T.setOnInput (Just InputTo)
+                |> T.setType "date"
+                |> T.setPlaceholder "Velg dato"
+                |> T.setTitle (Just "Til")
+                |> T.view
+            ]
         ]
 
 

--- a/src/elm/Page/History.elm
+++ b/src/elm/Page/History.elm
@@ -1,7 +1,7 @@
 module Page.History exposing (Model, Msg, init, subscriptions, update, view)
 
 import Base exposing (AppInfo)
-import Data.FareContract exposing (FareContract, FareContractState(..), FareTime, TravelRight(..))
+import Data.FareContract exposing (FareContract, FareContractState(..), TravelRight(..))
 import Data.RefData exposing (LangString(..))
 import Environment exposing (Environment)
 import Fragment.Icon as Icon
@@ -22,7 +22,7 @@ import Ui.Button as B
 import Ui.Group
 import Ui.Message
 import Ui.Section
-import Util.Format as Format exposing (date)
+import Util.Format as Format
 
 
 type Msg
@@ -117,7 +117,7 @@ update msg env model =
 
 
 view : Environment -> AppInfo -> Shared -> Model -> Maybe Route -> Html Msg
-view env _ shared model _ =
+view _ _ shared model _ =
     H.div [ A.class "page-history" ]
         [ H.div [ A.class "sidebar" ] [ viewSidebar model ]
         , H.div [ A.class "main" ] [ viewMain shared model ]
@@ -343,25 +343,6 @@ textInput value action title placeholder =
                 []
             ]
         ]
-
-
-fareContractStateToString : FareContractState -> String
-fareContractStateToString state =
-    case state of
-        FareContractStateUnspecified ->
-            "Unspecified"
-
-        FareContractStateNotActivated ->
-            "Not activated"
-
-        FareContractStateActivated ->
-            "Activated"
-
-        FareContractStateCancelled ->
-            "Cancelled"
-
-        FareContractStateRefunded ->
-            "Refunded"
 
 
 formatTotal : Maybe String -> String

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -236,24 +236,6 @@ p {
     }
 }
 
-.page-history {
-    display: grid;
-    grid-gap: 24px;
-    grid-template-columns: 320px 1fr;
-
-    .sidebar {
-        width: 320px;
-
-        input {
-            border: none;
-            outline: none;
-            background: inherit;
-            margin: 0;
-            padding: 0;
-        }
-    }
-}
-
 .page {
     display: grid;
     grid-gap: var(--spacings-xLarge);
@@ -277,9 +259,12 @@ p {
     grid-template-columns: 1fr;
 }
 
-.page--overview {
+.page--overview,
+.page--history {
     grid-template-columns: 1fr 2fr;
+}
 
+.page--overview {
     .ticket-header {
         display: flex;
 
@@ -350,7 +335,6 @@ p {
         padding: var(--spacings-medium);
     }
 
-    .page-history,
     .page {
         grid-template-columns: 1fr;
     }

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -252,38 +252,6 @@ p {
             padding: 0;
         }
     }
-
-    .main {
-        .order-header {
-            display: flex;
-            font-weight: 500;
-            cursor: pointer;
-
-            > div {
-                &:first-child {
-                    flex-grow: 1;
-                }
-            }
-        }
-    }
-
-    .receipt-button {
-        display: flex;
-        cursor: pointer;
-        background-color: inherit;
-        border: none;
-        width: 100%;
-        padding: 1.5rem;
-        border-radius: 0.25rem;
-        appearance: none;
-        text-align: left;
-        align-items: center;
-
-        > div:first-child {
-            flex-grow: 1;
-            font-weight: 500;
-        }
-    }
 }
 
 .page {

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -67,6 +67,7 @@
 .ui-section {
     border-radius: var(--border-radius-regular);
     overflow: hidden;
+    align-self: flex-start;
 }
 .ui-section--marginTop {
     margin-top: var(--spacings-xLarge);

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -359,6 +359,9 @@
     background: var(--colors-background_0-backgroundColor);
     color: var(--colors-background_0-color);
 }
+.ui-button--disabled {
+    cursor: not-allowed;
+}
 .ui-button--disabled > * {
     opacity: 0.2;
 }


### PR DESCRIPTION
Fixes #109

Skriver om history-visning til å være noe mer universelt utformet og responsive ved å bruke gjenbrukbare UI components. Legger også til warning-boks ved manglende epost for å gjøre det litt mer forståelig. Dette i påvente av full implementasjon av bedre flyt for sending av epost.

<img width="1071" alt="Screenshot 2021-05-03 at 22 55 44" src="https://user-images.githubusercontent.com/606374/116932741-f01ae900-ac62-11eb-8db1-5a9c0295f6c9.png">

