### PR TITLE
fix: render issues with Safari

### DIFF
--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -14,6 +14,11 @@
     --maxPageWidth: 976px;
 }
 
+* {
+    margin: 0;
+    padding: 0;
+}
+
 html,
 body {
     min-height: 100vh;

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -139,7 +139,6 @@
     align-items: center;
 
     transition: all 150ms ease-in-out;
-    border-radius: var(--border-radius-regular);
     border: var(--border-width-medium) solid transparent;
     // Remove border from padding.
     padding: calc(var(--spacings-xLarge) - 2 * var(--border-width-medium));
@@ -329,7 +328,6 @@
     outline: 0;
     border: var(--border-width-medium) solid
         var(--colors-primary_2-backgroundColor);
-    border-radius: var(--border-radius-regular);
 }
 .ui-button:not(.ui-button--compact) {
     width: 100%;
@@ -354,7 +352,6 @@
     outline: 0;
     border: var(--border-width-medium) solid
         var(--colors-primary_2-backgroundColor);
-    border-radius: var(--border-radius-regular);
 }
 .ui-button--tertiary {
     background: var(--colors-background_0-backgroundColor);


### PR DESCRIPTION
Safari har mer padding/margin på enkelte elementer enn andre nettlesere. Fremfor å kompensere for det på hvert element er det greit å nullstille ("normalize") for alle elementer. Dette burde ikke få store konsekvenser utenfor andre nettlesere men kan introdusere noe småfeil som jeg ikke fant etter gjennomgang her.

Fjerner også border-radius på fokus på punkter som en del av feil som ser litt rart ut i Safari som uansett skulle fikses opp i som en del av design sync på et tidspunkt.