### PR TITLE
fix: proper handling of label sizing as child of section

### DIFF
--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -85,8 +85,6 @@
     flex: 1;
     background: var(--colors-background_0-backgroundColor);
     color: var(--colors-background_0-color);
-    display: grid;
-    gap: var(--spacings-medium);
 }
 .ui-section__item--padded {
     padding: var(--spacings-xLarge);
@@ -450,6 +448,7 @@
 }
 
 .ui-input-text {
+    display: block;
     transition: all 150ms ease-in-out;
     border: var(--border-width-medium) solid transparent;
 


### PR DESCRIPTION
Det ble gjort en feil med håndtering av størrelser for labeling ved å sette section item til grid for å kompensere for størrelseshåndtering av input som barn i Safari. En bedre løsning er å faktisk definere label som block slik som var tiltenkt egentlig.