### PR TITLE
feat: adds validity to buy ticket summary

### DIFF
--- a/src/elm/Data/RemoteConfig.elm
+++ b/src/elm/Data/RemoteConfig.elm
@@ -1,0 +1,6 @@
+module Data.RemoteConfig exposing (RemoteConfig)
+
+
+type alias RemoteConfig =
+    { vat_percent : Int
+    }

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -25,6 +25,7 @@ import Time
 import Ui.Button as B exposing (ThemeColor(..))
 import Ui.Group
 import Ui.Input.Radio as Radio
+import Ui.LabelItem
 import Ui.Message as Message
 import Ui.Section as Section
 import Util.Format
@@ -599,7 +600,7 @@ summaryView _ model =
                         |> List.map (calculateOfferPrice model.users)
                         |> List.sum
                         |> round
-                        |> (\price -> "kr " ++ Util.Format.int price 2)
+                        |> (\price -> Util.Format.int price 2)
 
                 _ ->
                     "-"
@@ -609,8 +610,22 @@ summaryView _ model =
             |> Section.viewWithOptions
                 [ Section.viewHeader "Oppsummering"
                 , Section.viewPaddedItem
-                    [ H.div [ A.class "summary-price" ]
-                        [ H.text totalPrice
+                    [ Ui.LabelItem.viewHorizontal "Total:"
+                        [ H.div [ A.class "summary-price" ]
+                            [ H.text totalPrice
+                            , H.small [] [ H.text "kr" ]
+                            ]
+                        ]
+                    , Ui.LabelItem.viewHorizontal "Hvorav mva:"
+                        [ H.text "20 kr"
+                        ]
+                    ]
+                , Section.viewPaddedItem
+                    [ Ui.LabelItem.viewCompact "Gyldig fra"
+                        [ H.p [] [ H.text "321321" ]
+                        ]
+                    , Ui.LabelItem.viewCompact "Gyldig til"
+                        [ H.p [] [ H.text "321321" ]
                         ]
                     ]
                 , maybeBuyNotice model.users

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -627,19 +627,20 @@ summaryView shared model summary =
 
                   else
                     Section.viewPaddedItem
-                        [ Ui.LabelItem.viewHorizontal "Total:"
+                        [ Ui.LabelItem.viewHorizontal
+                            "Total:"
                             [ H.div [ A.class "summary-price" ]
                                 [ totalPrice
                                     |> Maybe.map (Func.flip Util.Format.float 2)
                                     |> Maybe.map H.text
-                                    |> Maybe.withDefault (Ui.LoadingText.view "2rem" "5rem")
+                                    |> Maybe.withDefault (Ui.LoadingText.view "1.6875rem" "5rem")
                                 , H.small [] [ H.text "kr" ]
                                 ]
                             ]
                         , Ui.LabelItem.viewHorizontal "Hvorav mva:"
                             [ vatAmount
                                 |> Maybe.map (Func.flip Util.Format.float 2)
-                                |> Maybe.map (Func.flip (++) "kr")
+                                |> Maybe.map (Func.flip (++) " kr")
                                 |> Maybe.map H.text
                                 |> Maybe.withDefault (Ui.LoadingText.view "1rem" "3rem")
                             ]

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -594,6 +594,14 @@ modelSummary shared model =
 summaryView : Shared -> Model -> ModelSummary -> Html Msg
 summaryView shared model summary =
     let
+        errorLoading =
+            case model.offers of
+                Failed _ ->
+                    True
+
+                _ ->
+                    False
+
         totalPrice =
             case model.offers of
                 Loaded offers ->
@@ -614,24 +622,28 @@ summaryView shared model summary =
             |> Section.setMarginBottom True
             |> Section.viewWithOptions
                 [ Section.viewHeader "Oppsummering"
-                , Section.viewPaddedItem
-                    [ Ui.LabelItem.viewHorizontal "Total:"
-                        [ H.div [ A.class "summary-price" ]
-                            [ totalPrice
+                , if errorLoading then
+                    Message.error "Fikk ikke lastet pris for denne billetten."
+
+                  else
+                    Section.viewPaddedItem
+                        [ Ui.LabelItem.viewHorizontal "Total:"
+                            [ H.div [ A.class "summary-price" ]
+                                [ totalPrice
+                                    |> Maybe.map (Func.flip Util.Format.float 2)
+                                    |> Maybe.map H.text
+                                    |> Maybe.withDefault (Ui.LoadingText.view "2rem" "5rem")
+                                , H.small [] [ H.text "kr" ]
+                                ]
+                            ]
+                        , Ui.LabelItem.viewHorizontal "Hvorav mva:"
+                            [ vatAmount
                                 |> Maybe.map (Func.flip Util.Format.float 2)
+                                |> Maybe.map (Func.flip (++) "kr")
                                 |> Maybe.map H.text
-                                |> Maybe.withDefault (Ui.LoadingText.view "2rem" "5rem")
-                            , H.small [] [ H.text "kr" ]
+                                |> Maybe.withDefault (Ui.LoadingText.view "1rem" "3rem")
                             ]
                         ]
-                    , Ui.LabelItem.viewHorizontal "Hvorav mva:"
-                        [ vatAmount
-                            |> Maybe.map (Func.flip Util.Format.float 2)
-                            |> Maybe.map (Func.flip (++) "kr")
-                            |> Maybe.map H.text
-                            |> Maybe.withDefault (Ui.LoadingText.view "1rem" "3rem")
-                        ]
-                    ]
                 , Section.viewPaddedItem
                     [ Ui.LabelItem.viewCompact "Gyldig fra"
                         [ H.p [] [ H.text <| Maybe.withDefault "" summary.start ]

--- a/src/elm/Service/RemoteConfig.elm
+++ b/src/elm/Service/RemoteConfig.elm
@@ -1,0 +1,40 @@
+port module Service.RemoteConfig exposing (init, onRemoteConfig)
+
+import Data.RefData exposing (FareProduct, LangString(..), TariffZone, UserProfile, UserType(..))
+import Data.RemoteConfig exposing (RemoteConfig)
+import Environment exposing (Environment)
+import Http
+import Json.Decode as Decode exposing (Decoder)
+import Json.Decode.Pipeline as DecodeP
+import Util.Http as HttpUtil
+
+
+init : RemoteConfig
+init =
+    { vat_percent = 6
+    }
+
+
+onRemoteConfig : (Result () RemoteConfig -> msg) -> Sub msg
+onRemoteConfig =
+    remoteConfigDecoder remoteConfigDataDecoder >> remoteConfigData
+
+
+
+-- INTERNAL
+
+
+port remoteConfigData : (Decode.Value -> msg) -> Sub msg
+
+
+remoteConfigDataDecoder : Decoder RemoteConfig
+remoteConfigDataDecoder =
+    Decode.succeed RemoteConfig
+        |> DecodeP.required "vat_percent" Decode.int
+
+
+remoteConfigDecoder : Decoder a -> (Result () a -> msg) -> (Decode.Value -> msg)
+remoteConfigDecoder decoder msg =
+    Decode.decodeValue decoder
+        >> Result.mapError (\_ -> ())
+        >> msg

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -1,16 +1,19 @@
 module Shared exposing (Msg, Shared, init, subscriptions, update)
 
 import Data.RefData exposing (FareProduct, Limitation, TariffZone, UserProfile, UserType)
+import Data.RemoteConfig exposing (RemoteConfig)
 import List exposing (product)
 import List.Extra
 import Service.Misc as MiscService exposing (Profile)
 import Service.RefData as RefDataService
+import Service.RemoteConfig as RCConfig
 
 
 type Msg
     = ReceiveTariffZones (Result () (List TariffZone))
     | ReceiveFareProducts (Result () (List FareProduct))
     | ReceiveUserProfiles (Result () (List UserProfile))
+    | ReceiveRemoteConfig (Result () RemoteConfig)
     | ProfileChange (Maybe Profile)
 
 
@@ -18,6 +21,7 @@ type alias Shared =
     { tariffZones : List TariffZone
     , fareProducts : List FareProduct
     , userProfiles : List UserProfile
+    , remoteConfig : RemoteConfig
     , productLimitations : List Limitation
     , profile : Maybe Profile
     }
@@ -30,6 +34,7 @@ init =
     , userProfiles = []
     , productLimitations = []
     , profile = Nothing
+    , remoteConfig = RCConfig.init
     }
 
 
@@ -66,6 +71,14 @@ update msg model =
                 Err _ ->
                     model
 
+        ReceiveRemoteConfig result ->
+            case result of
+                Ok value ->
+                    { model | remoteConfig = value }
+
+                Err _ ->
+                    model
+
         ProfileChange profile ->
             { model | profile = profile }
 
@@ -92,5 +105,6 @@ subscriptions =
         [ RefDataService.onTariffZones ReceiveTariffZones
         , RefDataService.onFareProducts ReceiveFareProducts
         , RefDataService.onUserProfiles ReceiveUserProfiles
+        , RCConfig.onRemoteConfig ReceiveRemoteConfig
         , MiscService.onProfileChange ProfileChange
         ]

--- a/src/elm/Ui/LabelItem.elm
+++ b/src/elm/Ui/LabelItem.elm
@@ -1,0 +1,38 @@
+module Ui.LabelItem exposing
+    ( view
+    , viewCompact
+    , viewHorizontal
+    )
+
+import Html as H exposing (Attribute, Html)
+import Html.Attributes as A
+import Ui.TextContainer as Text exposing (TextColor(..), TextContainer(..))
+
+
+view : String -> List (Html msg) -> Html msg
+view =
+    internalView [] []
+
+
+viewCompact : String -> List (Html msg) -> Html msg
+viewCompact =
+    internalView [] [ A.class "ui-labelItem__label--compact" ]
+
+
+viewHorizontal : String -> List (Html msg) -> Html msg
+viewHorizontal =
+    internalView [ A.class "ui-labelItem--horizontal" ] []
+
+
+
+-- Internal
+
+
+internalView : List (Attribute msg) -> List (Attribute msg) -> String -> List (Html msg) -> Html msg
+internalView attrs attrsChild label children =
+    H.div (A.class "ui-labelItem" :: attrs)
+        (H.div (A.class "ui-labelItem__label" :: attrsChild)
+            [ Text.textContainer (Just Text.SecondaryColor) <| Text.Tertiary [ H.text label ]
+            ]
+            :: children
+        )

--- a/src/elm/Ui/LoadingText.elm
+++ b/src/elm/Ui/LoadingText.elm
@@ -1,0 +1,9 @@
+module Ui.LoadingText exposing (view)
+
+import Html as H exposing (Html)
+import Html.Attributes as A
+
+
+view : String -> String -> Html msg
+view height width =
+    H.div [ A.class "ui-loadingText", A.style "height" height, A.style "width" width ] []

--- a/src/elm/Ui/Section.elm
+++ b/src/elm/Ui/Section.elm
@@ -4,7 +4,6 @@ module Ui.Section exposing
     , setMarginBottom
     , setMarginTop
     , view
-    , viewCompactLabelItem
     , viewHeader
     , viewItem
     , viewLabelItem
@@ -69,16 +68,6 @@ viewLabelItem : String -> List (Html msg) -> Html msg
 viewLabelItem label children =
     viewPaddedItem
         (H.div [ A.class "ui-section__item__label" ]
-            [ Text.textContainer (Just Text.SecondaryColor) <| Text.Tertiary [ H.text label ]
-            ]
-            :: children
-        )
-
-
-viewCompactLabelItem : String -> List (Html msg) -> Html msg
-viewCompactLabelItem label children =
-    viewPaddedItem
-        (H.div [ A.class "ui-section__item__label ui-section__item__label--compact" ]
             [ Text.textContainer (Just Text.SecondaryColor) <| Text.Tertiary [ H.text label ]
             ]
             :: children

--- a/src/elm/Ui/Section.elm
+++ b/src/elm/Ui/Section.elm
@@ -4,6 +4,7 @@ module Ui.Section exposing
     , setMarginBottom
     , setMarginTop
     , view
+    , viewCompactLabelItem
     , viewHeader
     , viewItem
     , viewLabelItem
@@ -68,6 +69,16 @@ viewLabelItem : String -> List (Html msg) -> Html msg
 viewLabelItem label children =
     viewPaddedItem
         (H.div [ A.class "ui-section__item__label" ]
+            [ Text.textContainer (Just Text.SecondaryColor) <| Text.Tertiary [ H.text label ]
+            ]
+            :: children
+        )
+
+
+viewCompactLabelItem : String -> List (Html msg) -> Html msg
+viewCompactLabelItem label children =
+    viewPaddedItem
+        (H.div [ A.class "ui-section__item__label ui-section__item__label--compact" ]
             [ Text.textContainer (Just Text.SecondaryColor) <| Text.Tertiary [ H.text label ]
             ]
             :: children

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -70,6 +70,19 @@ function fetchRemoteConfigData(port, key) {
     port.send(data);
 }
 
+function sendRemoteConfigVatPercent(port) {
+    if (!port) {
+        return;
+    }
+
+    const value = remoteConfig.getNumber('vat_percent');
+    if (value == null) {
+        return;
+    }
+
+    app.ports.remoteConfigVatPercent.send(value);
+}
+
 // NOTE: Only change this for testing.
 remoteConfig.settings.minimumFetchIntervalMillis = 3600000;
 //remoteConfig.settings.minimumFetchIntervalMillis = 60000;
@@ -88,7 +101,7 @@ remoteConfig
             app.ports.remoteConfigTariffZones,
             'tariff_zones'
         );
-        //fetchRemoteConfigData(app.ports.remoteConfigSalesPackages, 'sales_packages');
+        sendRemoteConfigVatPercent();
     })
     .catch((err) => {
         // ...

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -510,7 +510,7 @@ p {
     font-size: 2rem;
     line-height: 1;
     display: flex;
-    align-items: flex-end;
+    align-items: baseline;
     small {
         font-size: 1rem;
     }

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -508,6 +508,9 @@ p {
 
 .summary-price {
     font-size: 2rem;
+    line-height: 1;
+    display: flex;
+    align-items: flex-end;
     small {
         font-size: 1rem;
     }

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -507,9 +507,10 @@ p {
 }
 
 .summary-price {
-    text-align: right;
-    font-size: 32px;
-    place-items: center end;
+    font-size: 2rem;
+    small {
+        font-size: 1rem;
+    }
 }
 
 @keyframes ticket-progress-move {

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -539,3 +539,38 @@
         opacity: 1;
     }
 }
+
+// LoadingText.elm
+
+.ui-loadingText {
+    animation: placeHolderShimmer 1s linear infinite forwards,
+        opacityIn 400ms ease;
+    background: var(--colors-background_0-backgroundColor);
+    background: linear-gradient(
+        to right,
+        var(--colors-background_2-backgroundColor) 8%,
+        var(--colors-background_0-backgroundColor) 18%,
+        var(--colors-background_2-backgroundColor) 33%
+    );
+    background-size: 800px 104px;
+    height: 1rem;
+    position: relative;
+    display: inline-block;
+    margin: 0 var(--spacings-xSmall);
+}
+@keyframes placeHolderShimmer {
+    0% {
+        background-position: -468px 0;
+    }
+    100% {
+        background-position: 468px 0;
+    }
+}
+@keyframes opacityIn {
+    0% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+}

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -92,6 +92,9 @@
 .ui-section__item__label {
     margin-bottom: var(--spacings-medium);
 }
+.ui-section__item__label--compact {
+    margin-bottom: var(--spacings-xSmall);
+}
 .ui-section__child:not(:last-child) {
     border-bottom: var(--border-width-slim) solid
         var(--colors-background_1-backgroundColor);
@@ -100,6 +103,23 @@
     padding: 0;
     margin: 0;
 }
+
+// Style for ./src/Ui/LabelItem.elm
+.ui-labelItem__label {
+    margin-bottom: var(--spacings-medium);
+}
+.ui-labelItem--horizontal {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+.ui-labelItem + .ui-labelItem {
+    margin-top: var(--spacings-medium);
+}
+.ui-labelItem__label--compact {
+    margin-bottom: var(--spacings-xSmall);
+}
+// End: Style for LabelItem.elm
 
 .ui-group {
     width: 100%;

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -112,6 +112,11 @@
     display: flex;
     justify-content: space-between;
     flex-wrap: wrap;
+    align-items: baseline;
+
+    .ui-labelItem__label {
+        margin-bottom: 0;
+    }
 }
 .ui-labelItem + .ui-labelItem {
     margin-top: var(--spacings-medium);

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -85,8 +85,6 @@
     flex: 1;
     background: var(--colors-background_0-backgroundColor);
     color: var(--colors-background_0-color);
-    display: grid;
-    gap: var(--spacings-medium);
 }
 .ui-section__item--padded {
     padding: var(--spacings-xLarge);
@@ -450,6 +448,7 @@
 }
 
 .ui-input-text {
+    display: block;
     transition: all 150ms ease-in-out;
     border: var(--border-width-medium) solid transparent;
 


### PR DESCRIPTION
Fixes #20

Legger til MVA og gyldig fra i oppsummeringen. Ingen enkel måte å hente ut `gyldig til` akkurat nå. Så vi må eventuelt finne ut en måte å kalkulere det på på et vis.

Legger også opp til å kunne hente ut mer info fra RemoteConfig (som feature toggles etterhvert).

![Screenshot 2021-05-06 at 08 10 00](https://user-images.githubusercontent.com/606374/117249783-76415600-ae42-11eb-96ac-2345b3341fcc.png)
