### PR TITLE
feat: adds initial naive google analytics

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -22,6 +22,7 @@ jobs:
               env:
                   WEBSHOP_BASE_URL: ${{ secrets.BASE_URL_PRODUCTION }}
                   WEBSHOP_FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG_PRODUCTION }}
+                  GA_TRACKING_ID: ${{ secrets.GA_TRACKING_ID }}
             - uses: FirebaseExtended/action-hosting-deploy@v0
               with:
                   repoToken: '${{ secrets.GITHUB_TOKEN }}'

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ can use environment variables:
     JSON, so remember when copying the config from the Firebase console to change
     the keys to be double-quoted strings (this is only necessary when using an
     environment variable).
+-   `GA_TRACKING_ID`: Optional Google Analytics code.
 
 There is also support for using a `.env` file containing these variables.
 
@@ -81,7 +82,8 @@ module.exports = {
     host: '0.0.0.0',
     port: 8112,
     baseUrl: 'http://localhost',
-    firebaseConfig: {...}
+    firebaseConfig: {...},
+    gaTrackingId: '' // optional Google Analytics code
 };
 ```
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -25,10 +25,11 @@
             rel="stylesheet"
         />
 
+        <% if (typeof gaTrackingId != 'undefined') { %>
         <!-- Global site tag (gtag.js) - Google Analytics -->
         <script
             async
-            src="https://www.googletagmanager.com/gtag/js?id=G-ZJNT7JRC05"
+            src="https://www.googletagmanager.com/gtag/js?id=<%= gaTrackingId %>"
         ></script>
         <script>
             window.dataLayer = window.dataLayer || [];
@@ -36,8 +37,9 @@
                 dataLayer.push(arguments);
             }
             gtag('js', new Date());
-            gtag('config', 'G-ZJNT7JRC05');
+            gtag('config', '<%= gaTrackingId %>');
         </script>
+        <% } %>
 
         <script>
             // We pre-filled your app ID in the widget URL: 'https://widget.intercom.io/widget/vdemedo2'

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -25,6 +25,20 @@
             rel="stylesheet"
         />
 
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script
+            async
+            src="https://www.googletagmanager.com/gtag/js?id=G-ZJNT7JRC05"
+        ></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+                dataLayer.push(arguments);
+            }
+            gtag('js', new Date());
+            gtag('config', 'G-ZJNT7JRC05');
+        </script>
+
         <script>
             // We pre-filled your app ID in the widget URL: 'https://widget.intercom.io/widget/vdemedo2'
             (function () {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -342,6 +342,9 @@ const commonConfig = {
                 version: gitDescribe(),
                 commit: gitCommitHash()
             }),
+            gaTrackingId: JSON.stringify(
+                process.env.GA_TRACKING_ID || localConfig.gaTrackingId
+            ),
             firebaseConfig: JSON.stringify(getFirebaseConfig(localConfig))
         })
     ]


### PR DESCRIPTION
Dette er ikke en fullverdig løsning, men det gir oss noe å gå på. Ettersom det er mye klientside navigasjon så er det ikke alle ting som fanges opp her. Må på et tidspunkt utvide dette til å ha en Elm-bibliotek som lar oss trigge events fra forskjellige effekter (klikk, navigasjon, etc).

Men akkurat nå får vi i alle fall noe statistikk inn i samme kanal som øvrige ting. Noe av dette finnes nok sikkert via Firebase også.