### PR TITLE
feat: Improves purchase flow for better a11y and robustness 

### DIFF
--- a/src/elm/Data/Ticket.elm
+++ b/src/elm/Data/Ticket.elm
@@ -4,6 +4,7 @@ module Data.Ticket exposing
     , PaymentType(..)
     , Price
     , Reservation
+    , ReservationStatus(..)
     , Ticket
     )
 
@@ -34,6 +35,11 @@ type alias Offer =
     , prices : List Price
     , travellerId : String
     }
+
+
+type ReservationStatus
+    = Captured
+    | NotCaptured
 
 
 type alias Reservation =

--- a/src/elm/Data/Ticket.elm
+++ b/src/elm/Data/Ticket.elm
@@ -1,6 +1,5 @@
 module Data.Ticket exposing
-    ( ActiveReservation
-    , Offer
+    ( Offer
     , PaymentStatus
     , PaymentType(..)
     , Price
@@ -42,13 +41,6 @@ type alias Reservation =
     , paymentId : Int
     , transactionId : Int
     , url : String
-    }
-
-
-type alias ActiveReservation =
-    { reservation : Reservation
-    , offers : List Offer
-    , paymentStatus : Maybe PaymentStatus
     }
 
 

--- a/src/elm/GlobalActions.elm
+++ b/src/elm/GlobalActions.elm
@@ -3,7 +3,6 @@ module GlobalActions exposing
     , map
     )
 
-import Data.Ticket exposing (ActiveReservation)
 import Notification exposing (Notification)
 import Route as Route
 
@@ -15,7 +14,6 @@ type GlobalAction msg
     | OpenShop
     | OpenEditTravelCard
     | CloseShop
-    | AddActiveReservation ActiveReservation
     | FocusItem (Maybe String)
     | Logout
 
@@ -40,9 +38,6 @@ map f ga =
 
         CloseShop ->
             CloseShop
-
-        AddActiveReservation reservation ->
-            AddActiveReservation reservation
 
         Logout ->
             Logout

--- a/src/elm/GlobalActions.elm
+++ b/src/elm/GlobalActions.elm
@@ -11,9 +11,7 @@ type GlobalAction msg
     = RouteTo Route.Route
     | ShowNotification (Notification msg)
     | SetCustomerNumber Int
-    | OpenShop
     | OpenEditTravelCard
-    | CloseShop
     | FocusItem (Maybe String)
     | Logout
 
@@ -30,14 +28,8 @@ map f ga =
         SetCustomerNumber number ->
             SetCustomerNumber number
 
-        OpenShop ->
-            OpenShop
-
         OpenEditTravelCard ->
             OpenEditTravelCard
-
-        CloseShop ->
-            CloseShop
 
         Logout ->
             Logout

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -474,7 +474,7 @@ header model =
             , ( "Min profil", Route.Settings )
             ]
 
-        showLogout =
+        showHeader =
             model.environment.customerId /= Nothing || model.onboarding /= Nothing
 
         navigation =
@@ -493,9 +493,6 @@ header model =
 
             else
                 []
-
-        showHeader =
-            showLogout && model.route /= Just Route.Thanks
     in
         H.header [ A.class "pageHeader" ]
             [ H.div [ A.class "pageHeader__content" ]
@@ -578,9 +575,6 @@ viewPage model =
                 AccountPage.view env model.appInfo shared model.account model.route
                     |> H.map AccountMsg
                     |> wrapSubPage "Min profil"
-
-            Just Route.Thanks ->
-                viewSuccessTicketPage
 
             _ ->
                 OverviewPage.view env model.appInfo shared model.overview model.route

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -22,7 +22,7 @@ import Page.Onboarding as OnboardingPage
 import Page.Overview as OverviewPage
 import Page.Shop as ShopPage
 import PageUpdater exposing (PageUpdater)
-import Route exposing (ResponseCode, Route)
+import Route exposing (Route)
 import Service.FirebaseAuth as FirebaseAuth
 import Service.Misc as MiscService
 import Shared exposing (Shared)

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -22,7 +22,7 @@ import Page.Onboarding as OnboardingPage
 import Page.Overview as OverviewPage
 import Page.Shop as ShopPage
 import PageUpdater exposing (PageUpdater)
-import Route exposing (Route)
+import Route exposing (ResponseCode, Route)
 import Service.FirebaseAuth as FirebaseAuth
 import Service.Misc as MiscService
 import Shared exposing (Shared)
@@ -114,6 +114,11 @@ setRoute maybeRoute model =
                 noPaymentId =
                     maybeReservation.paymentId == Nothing
 
+                isCancelled =
+                    maybeReservation.responseCode
+                        |> Maybe.map ((==) Route.Cancel)
+                        |> Maybe.withDefault False
+
                 reservation =
                     { transactionId = Maybe.withDefault 1 maybeReservation.transactionId
                     , paymentId = Maybe.withDefault 1 maybeReservation.paymentId
@@ -121,7 +126,7 @@ setRoute maybeRoute model =
                     , url = ""
                     }
             in
-                if noPaymentId then
+                if noPaymentId || isCancelled then
                     Route.modifyUrl model.navKey Route.Home
 
                 else

--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -3,7 +3,7 @@ module Page.Overview exposing (Model, Msg(..), init, subscriptions, update, view
 import Base exposing (AppInfo)
 import Data.FareContract exposing (FareContract, FareContractState(..), TravelRight(..))
 import Data.RefData exposing (LangString(..))
-import Data.Ticket exposing (PaymentStatus, Reservation)
+import Data.Ticket exposing (PaymentStatus, Reservation, ReservationStatus(..))
 import Data.Webshop exposing (Inspection, Token)
 import Environment exposing (Environment)
 import Fragment.Icon as Icon
@@ -49,11 +49,6 @@ type Msg
     | AddActiveReservation Reservation
     | Logout
     | ReceivePaymentStatus Int (Result Http.Error PaymentStatus)
-
-
-type ReservationStatus
-    = Captured
-    | NotCaptured
 
 
 type alias Model =
@@ -330,7 +325,7 @@ viewMain shared model =
 viewPending : Model -> List (Html msg)
 viewPending model =
     model.reservations
-        |> List.map (Tuple.first >> Ui.TicketDetails.viewActivation)
+        |> List.map Ui.TicketDetails.viewActivation
 
 
 viewTicketCards : Shared -> List FareContract -> Model -> List (Html Msg)

--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -132,7 +132,7 @@ update msg env model =
 
         OpenShop ->
             PageUpdater.init model
-                |> PageUpdater.addGlobalAction GA.OpenShop
+                |> PageUpdater.addGlobalAction (GA.RouteTo Route.Shop)
 
         OpenHistory ->
             PageUpdater.init model

--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -30,7 +30,6 @@ import Util.FareContract
 import Util.Maybe
 import Util.PhoneNumber
 import Util.Status exposing (Status(..))
-import Util.TravelCard
 
 
 type Msg

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -14,6 +14,7 @@ import Http
 import List.Extra
 import Notification
 import PageUpdater exposing (PageUpdater)
+import Process
 import Route exposing (Route)
 import Service.Misc as MiscService
 import Service.Ticket as TicketService
@@ -37,7 +38,9 @@ import Util.Time as TimeUtil
 
 
 type Msg
-    = FetchOffers
+    = OnEnterPage
+    | OnLeavePage
+    | FetchOffers
     | ReceiveOffers (Result Http.Error (List Offer))
     | BuyOffers PaymentType
     | ReceiveBuyOffers (Result Http.Error Reservation)
@@ -70,9 +73,9 @@ type TravelDateTime
 
 
 type alias Model =
-    { product : String
-    , fromZone : String
-    , toZone : String
+    { product : Maybe String
+    , fromZone : Maybe String
+    , toZone : Maybe String
     , users : List ( UserType, Int )
     , offers : Status (List Offer)
     , reservation : Status Reservation
@@ -85,43 +88,26 @@ type alias Model =
     }
 
 
-init : Shared -> ( Model, Cmd Msg )
-init shared =
-    let
-        firstZone =
-            shared.tariffZones
-                |> List.sortWith
-                    (\a b ->
-                        case ( a.name, b.name ) of
-                            ( LangString _ nameA, LangString _ nameB ) ->
-                                compare nameA nameB
-                    )
-                |> List.head
-                |> Maybe.map .id
-                |> Maybe.withDefault ""
-    in
-        ( { product =
-                shared.availableFareProducts
-                    |> List.head
-                    |> Maybe.map .id
-                    |> Maybe.withDefault ""
-          , fromZone = firstZone
-          , toZone = firstZone
-          , users = [ ( UserTypeAdult, 1 ) ]
-          , offers = NotLoaded
-          , reservation = NotLoaded
-          , mainView = Duration
-          , travelDateTime = TravelNow
-          , now = Time.millisToPosix 0
-          , inputTravelDate = ""
-          , inputTravelTime = ""
-          , timeZone = Time.utc
-          }
-        , Cmd.batch
-            [ TaskUtil.doTask FetchOffers
-            , Task.perform UpdateZone Time.here
-            ]
-        )
+init : ( Model, Cmd Msg )
+init =
+    ( { product = Nothing
+      , fromZone = Nothing
+      , toZone = Nothing
+      , users = [ ( UserTypeAdult, 1 ) ]
+      , offers = NotLoaded
+      , reservation = NotLoaded
+      , mainView = Duration
+      , travelDateTime = TravelNow
+      , now = Time.millisToPosix 0
+      , inputTravelDate = ""
+      , inputTravelTime = ""
+      , timeZone = Time.utc
+      }
+    , Cmd.batch
+        [ TaskUtil.doTask FetchOffers
+        , Task.perform UpdateZone Time.here
+        ]
+    )
 
 
 update : Msg -> Environment -> Model -> Shared -> PageUpdater Model Msg
@@ -135,21 +121,27 @@ update msg env model shared =
                 |> PageUpdater.addGlobalAction
     in
         case msg of
+            OnEnterPage ->
+                PageUpdater.fromPair init
+
+            OnLeavePage ->
+                PageUpdater.init model
+
             SetProduct product _ ->
                 PageUpdater.fromPair
-                    ( { model | product = product, users = maybeResetUsers shared product model.users }
+                    ( { model | product = Just product, users = maybeResetUsers shared product model.users }
                     , TaskUtil.doTask FetchOffers
                     )
 
             SetFromZone zone ->
                 PageUpdater.fromPair
-                    ( { model | fromZone = zone }
+                    ( { model | fromZone = Just zone }
                     , TaskUtil.doTask FetchOffers
                     )
 
             SetToZone zone ->
                 PageUpdater.fromPair
-                    ( { model | toZone = zone }
+                    ( { model | toZone = Just zone }
                     , TaskUtil.doTask FetchOffers
                     )
 
@@ -244,6 +236,21 @@ update msg env model shared =
                                 _ ->
                                     Nothing
 
+                        ( firstZone, defaultProduct ) =
+                            defaultDerivedData shared
+
+                        dataNotLoadedYet =
+                            List.isEmpty shared.availableFareProducts && List.isEmpty shared.tariffZones
+
+                        newProduct =
+                            Maybe.withDefault defaultProduct model.product
+
+                        newFromZone =
+                            Maybe.withDefault firstZone model.fromZone
+
+                        newToZone =
+                            Maybe.withDefault firstZone model.toZone
+
                         travelTime =
                             case model.travelDateTime of
                                 TravelFuture (Just time) ->
@@ -252,15 +259,28 @@ update msg env model shared =
                                 _ ->
                                     Nothing
                     in
-                        PageUpdater.fromPair
-                            ( { model | offers = Loading oldOffers, reservation = NotLoaded }
-                            , fetchOffers env
-                                model.product
-                                model.fromZone
-                                model.toZone
-                                model.users
-                                travelTime
-                            )
+                        if dataNotLoadedYet then
+                            PageUpdater.fromPair
+                                ( model
+                                , Process.sleep 500 |> Task.attempt (\_ -> FetchOffers)
+                                )
+
+                        else
+                            PageUpdater.fromPair
+                                ( { model
+                                    | offers = Loading oldOffers
+                                    , reservation = NotLoaded
+                                    , product = Just newProduct
+                                    , fromZone = Just newFromZone
+                                    , toZone = Just newToZone
+                                  }
+                                , fetchOffers env
+                                    newProduct
+                                    newFromZone
+                                    newToZone
+                                    model.users
+                                    travelTime
+                                )
 
             ReceiveOffers result ->
                 case result of
@@ -315,7 +335,7 @@ update msg env model shared =
 
             CloseShop ->
                 PageUpdater.init model
-                    |> PageUpdater.addGlobalAction GA.CloseShop
+                    |> PageUpdater.addGlobalAction (GA.RouteTo Route.Home)
 
             ShowView mainView ->
                 PageUpdater.init (toggleShowMainView model mainView)
@@ -343,6 +363,30 @@ update msg env model shared =
                     ( model
                     , TaskUtil.doTask <| SetTravelDateTime <| TravelFuture (Just isoTime)
                     )
+
+
+defaultDerivedData : Shared -> ( String, String )
+defaultDerivedData shared =
+    let
+        firstZone =
+            shared.tariffZones
+                |> List.sortWith
+                    (\a b ->
+                        case ( a.name, b.name ) of
+                            ( LangString _ nameA, LangString _ nameB ) ->
+                                compare nameA nameB
+                    )
+                |> List.head
+                |> Maybe.map .id
+                |> Maybe.withDefault ""
+
+        defaultProduct =
+            shared.availableFareProducts
+                |> List.head
+                |> Maybe.map .id
+                |> Maybe.withDefault ""
+    in
+        ( firstZone, defaultProduct )
 
 
 maybeResetUsers : Shared -> String -> List ( UserType, Int ) -> List ( UserType, Int )
@@ -374,8 +418,11 @@ toggleShowMainView model mainView =
 view : Environment -> AppInfo -> Shared -> Model -> Maybe Route -> Html Msg
 view _ _ shared model _ =
     let
+        ( defaultZone, defaultProduct ) =
+            defaultDerivedData shared
+
         summary =
-            modelSummary shared model
+            modelSummary ( defaultZone, defaultProduct ) shared model
 
         errorMessage =
             case model.offers of
@@ -428,7 +475,7 @@ view _ _ shared model _ =
                     , onOpenClick = Just (ShowView Duration)
                     , id = "varighet"
                     }
-                    [ viewProducts model shared.availableFareProducts ]
+                    [ viewProducts model defaultProduct shared.availableFareProducts ]
                 , Ui.Group.view
                     { title = "Reisende"
                     , icon = Just Icon.bus
@@ -441,7 +488,7 @@ view _ _ shared model _ =
                     , onOpenClick = Just (ShowView Travelers)
                     , id = "reisende"
                     }
-                    [ viewUserProfiles model shared ]
+                    [ viewUserProfiles defaultProduct model shared ]
                 , Ui.Group.view
                     { title = "Gyldig fra og med"
                     , icon = Just Icon.ticket
@@ -461,7 +508,7 @@ view _ _ shared model _ =
                     , onOpenClick = Just (ShowView Zones)
                     , id = "zones"
                     }
-                    [ viewZones model shared.tariffZones ]
+                    [ viewZones model defaultZone shared.tariffZones ]
                 ]
             , H.div []
                 [ summaryView shared model summary
@@ -516,8 +563,8 @@ stringFromStart model =
             Nothing
 
 
-stringFromZone : List TariffZone -> Model -> Maybe String
-stringFromZone tariffZones model =
+stringFromZone : List TariffZone -> String -> Model -> Maybe String
+stringFromZone tariffZones defaultZone model =
     let
         findName zone =
             tariffZones
@@ -526,10 +573,10 @@ stringFromZone tariffZones model =
                 |> Maybe.withDefault "-"
 
         fromZoneName =
-            findName model.fromZone
+            findName (Maybe.withDefault defaultZone model.fromZone)
 
         toZoneName =
-            findName model.toZone
+            findName (Maybe.withDefault defaultZone model.toZone)
     in
         if model.fromZone == model.toZone then
             Just <| "Reise i 1 sone (" ++ fromZoneName ++ ")"
@@ -546,16 +593,20 @@ type alias ModelSummary =
     }
 
 
-modelSummary : Shared -> Model -> ModelSummary
-modelSummary shared model =
-    { users =
-        model.users
-            |> List.map
-                (Tuple.mapFirst (\a -> a |> nameFromUserType shared.userProfiles |> Maybe.withDefault "-"))
-    , duration = nameFromFareProduct shared.fareProducts model.product
-    , start = stringFromStart model
-    , zones = stringFromZone shared.tariffZones model
-    }
+modelSummary : ( String, String ) -> Shared -> Model -> ModelSummary
+modelSummary ( defaultZone, defaultProduct ) shared model =
+    let
+        product =
+            Maybe.withDefault defaultProduct model.product
+    in
+        { users =
+            model.users
+                |> List.map
+                    (Tuple.mapFirst (\a -> a |> nameFromUserType shared.userProfiles |> Maybe.withDefault "-"))
+        , duration = nameFromFareProduct shared.fareProducts product
+        , start = stringFromStart model
+        , zones = stringFromZone shared.tariffZones defaultZone model
+        }
 
 
 summaryView : Shared -> Model -> ModelSummary -> Html Msg
@@ -707,18 +758,21 @@ viewStart model =
         ]
 
 
-viewProducts : Model -> List FareProduct -> Html Msg
-viewProducts model products =
+viewProducts : Model -> String -> List FareProduct -> Html Msg
+viewProducts model defaultProduct products =
     products
-        |> List.map (viewProduct model)
+        |> List.map (viewProduct model defaultProduct)
         |> Radio.viewGroup "Velg billettype"
 
 
-viewProduct : Model -> FareProduct -> Html Msg
-viewProduct model product =
+viewProduct : Model -> String -> FareProduct -> Html Msg
+viewProduct model defaultProduct product =
     let
+        selectedProduct =
+            Maybe.withDefault defaultProduct model.product
+
         isCurrent =
-            model.product == product.id
+            selectedProduct == product.id
     in
         Radio.init product.id
             |> Radio.setTitle (langString product.name)
@@ -728,8 +782,8 @@ viewProduct model product =
             |> Radio.view
 
 
-viewZones : Model -> List TariffZone -> Html Msg
-viewZones model zones =
+viewZones : Model -> String -> List TariffZone -> Html Msg
+viewZones model defaultZone zones =
     let
         sortedZones =
             List.sortWith
@@ -739,11 +793,17 @@ viewZones model zones =
                             compare nameA nameB
                 )
                 zones
+
+        selectedFromZone =
+            Maybe.withDefault defaultZone model.fromZone
+
+        selectedToZone =
+            Maybe.withDefault defaultZone model.toZone
     in
         Section.viewItem
             [ Section.viewHorizontalGroup
-                [ Section.viewLabelItem "Avreisesone" [ H.select [ E.onInput SetFromZone ] <| List.map (viewZone model.fromZone) sortedZones ]
-                , Section.viewLabelItem "Ankomstsone" [ H.select [ E.onInput SetToZone ] <| List.map (viewZone model.toZone) sortedZones ]
+                [ Section.viewLabelItem "Avreisesone" [ H.select [ E.onInput SetFromZone ] <| List.map (viewZone selectedFromZone) sortedZones ]
+                , Section.viewLabelItem "Ankomstsone" [ H.select [ E.onInput SetToZone ] <| List.map (viewZone selectedToZone) sortedZones ]
                 ]
             , Section.viewPaddedItem [ H.p [] [ H.a [ A.href "https://atb.no/soner", A.target "_blank" ] [ H.text "Se sonekart og beskrivelser" ] ] ]
             ]
@@ -758,13 +818,17 @@ viewZone current zone =
         [ H.text <| langString zone.name ]
 
 
-viewUserProfiles : Model -> Shared -> Html Msg
-viewUserProfiles model shared =
-    shared.userProfiles
-        |> List.filter (.userType >> Func.flip List.member (findLimitations model.product shared.productLimitations))
-        |> List.filter (.userType >> (/=) UserTypeAnyone)
-        |> List.map (viewUserProfile model)
-        |> Radio.viewGroup "Reisende"
+viewUserProfiles : String -> Model -> Shared -> Html Msg
+viewUserProfiles defaultProduct model shared =
+    let
+        product =
+            Maybe.withDefault defaultProduct model.product
+    in
+        shared.userProfiles
+            |> List.filter (.userType >> Func.flip List.member (findLimitations product shared.productLimitations))
+            |> List.filter (.userType >> (/=) UserTypeAnyone)
+            |> List.map (viewUserProfile model)
+            |> Radio.viewGroup "Reisende"
 
 
 findLimitations : String -> List Limitation -> List UserType

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -40,6 +40,7 @@ import Util.Time as TimeUtil
 type Msg
     = OnEnterPage
     | OnLeavePage
+    | ResetState
     | FetchOffers
     | ReceiveOffers (Result Http.Error (List Offer))
     | BuyOffers PaymentType
@@ -121,8 +122,11 @@ update msg env model shared =
                 |> PageUpdater.addGlobalAction
     in
         case msg of
+            ResetState ->
+                PageUpdater.init <| Tuple.first init
+
             OnEnterPage ->
-                PageUpdater.fromPair init
+                PageUpdater.fromPair ( model, Tuple.second init )
 
             OnLeavePage ->
                 PageUpdater.init model
@@ -338,7 +342,7 @@ update msg env model shared =
                                 |> addGlobalNotification (Message.Error errorMessage)
 
             CloseShop ->
-                PageUpdater.init model
+                PageUpdater.fromPair ( model, TaskUtil.doTask ResetState )
                     |> PageUpdater.addGlobalAction (GA.RouteTo Route.Home)
 
             ShowView mainView ->

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -305,7 +305,7 @@ update msg env model shared =
                         PageUpdater.fromPair
                             ( { model | reservation = Loaded reservation }
                             , Cmd.batch
-                                [ MiscService.openWindow reservation.url
+                                [ MiscService.navigateTo reservation.url
                                 , fetchPaymentStatus env reservation.paymentId
                                 ]
                             )

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -199,7 +199,8 @@ update msg env model shared =
                         List.filter (Tuple.first >> (/=) userType) users
 
                     user =
-                        List.filter (Tuple.first >> (==) userType) users
+                        users
+                            |> List.filter (Tuple.first >> (==) userType)
                             |> List.head
 
                     newValue =
@@ -308,10 +309,13 @@ update msg env model shared =
                                             |> Maybe.map (\( _, count ) -> ( offer.offerId, count ))
                                     )
                                     offers
+
+                            phone =
+                                Maybe.map .phone shared.profile
                         in
                             PageUpdater.fromPair
                                 ( { model | reservation = Loading Nothing }
-                                , buyOffers env paymentType offerCounts
+                                , buyOffers env phone paymentType offerCounts
                                 )
 
                     _ ->
@@ -876,10 +880,10 @@ fetchOffers env product fromZone toZone users travelDate =
         |> Task.attempt ReceiveOffers
 
 
-buyOffers : Environment -> PaymentType -> List ( String, Int ) -> Cmd Msg
-buyOffers env paymentType offerCounts =
+buyOffers : Environment -> Maybe String -> PaymentType -> List ( String, Int ) -> Cmd Msg
+buyOffers env phone paymentType offerCounts =
     offerCounts
-        |> TicketService.reserve env paymentType
+        |> TicketService.reserve env phone paymentType
         |> Http.toTask
         |> Task.attempt ReceiveBuyOffers
 

--- a/src/elm/Route.elm
+++ b/src/elm/Route.elm
@@ -18,7 +18,7 @@ import Url.Parser.Query as QueryParser
 type Route
     = Home
     | Shop
-    | Thanks ConfirmQuery
+    | Payment ConfirmQuery
     | History
     | Settings
     | NotFound
@@ -45,7 +45,7 @@ parser =
         [ Parser.map Home Parser.top
         , Parser.map Shop <| s "shop"
         , Parser.map History <| s "history"
-        , Parser.map Thanks <| s "thanks" <?> thanksQueryParser
+        , Parser.map Payment <| s "payment" <?> thanksQueryParser
         , Parser.map Settings <| s "settings"
         ]
 
@@ -58,7 +58,7 @@ routeToString page =
                 Home ->
                     []
 
-                Thanks _ ->
+                Payment _ ->
                     []
 
                 Shop ->

--- a/src/elm/Route.elm
+++ b/src/elm/Route.elm
@@ -11,16 +11,32 @@ import Browser.Navigation as Nav
 import Html exposing (Attribute)
 import Html.Attributes as A
 import Url exposing (Url)
-import Url.Parser as Parser exposing ((</>), Parser, oneOf, s)
+import Url.Parser as Parser exposing ((</>), (<?>), Parser, oneOf, s)
+import Url.Parser.Query as QueryParser
 
 
 type Route
     = Home
     | Shop
-    | Thanks
+    | Thanks ConfirmQuery
     | History
     | Settings
     | NotFound
+
+
+type alias ConfirmQuery =
+    { transactionId : Maybe Int
+    , paymentId : Maybe Int
+    , orderId : Maybe String
+    }
+
+
+thanksQueryParser : QueryParser.Parser ConfirmQuery
+thanksQueryParser =
+    QueryParser.map3 ConfirmQuery
+        (QueryParser.int "transaction_id")
+        (QueryParser.int "payment_id")
+        (QueryParser.string "order_id")
 
 
 parser : Parser (Route -> a) a
@@ -29,7 +45,7 @@ parser =
         [ Parser.map Home Parser.top
         , Parser.map Shop <| s "shop"
         , Parser.map History <| s "history"
-        , Parser.map Thanks <| s "thanks"
+        , Parser.map Thanks <| s "thanks" <?> thanksQueryParser
         , Parser.map Settings <| s "settings"
         ]
 
@@ -42,11 +58,11 @@ routeToString page =
                 Home ->
                     []
 
+                Thanks _ ->
+                    []
+
                 Shop ->
                     [ "shop" ]
-
-                Thanks ->
-                    [ "thanks" ]
 
                 History ->
                     [ "history" ]

--- a/src/elm/Service/Misc.elm
+++ b/src/elm/Service/Misc.elm
@@ -4,10 +4,10 @@ port module Service.Misc exposing
     , convertTime
     , convertedTime
     , fareContractDecoder
+    , navigateTo
     , onProfileChange
     , onboardingDone
     , onboardingStart
-    , openWindow
     , receiveFareContracts
     , receiveTokens
     , saveProfile
@@ -19,7 +19,7 @@ import Json.Decode.Pipeline as DecodeP
 import Json.Encode as Encode
 
 
-port openWindow : String -> Cmd msg
+port navigateTo : String -> Cmd msg
 
 
 port bodyClass : String -> Cmd msg

--- a/src/elm/Service/Ticket.elm
+++ b/src/elm/Service/Ticket.elm
@@ -54,7 +54,7 @@ reserve env paymentType offers =
             Encode.object
                 [ ( "offers", Encode.list encodeOffer offers )
                 , ( "payment_type", encodePaymentType paymentType )
-                , ( "payment_redirect_url", Encode.string (env.localUrl ++ "/thanks") )
+                , ( "payment_redirect_url", Encode.string (env.localUrl ++ "/?transaction_id={transaction_id}&payment_id={payment_id}&order_id={order_id}") )
                 ]
     in
         HttpUtil.post env url (Http.jsonBody body) (Http.expectJson reservationDecoder)

--- a/src/elm/Service/Ticket.elm
+++ b/src/elm/Service/Ticket.elm
@@ -54,7 +54,7 @@ reserve env paymentType offers =
             Encode.object
                 [ ( "offers", Encode.list encodeOffer offers )
                 , ( "payment_type", encodePaymentType paymentType )
-                , ( "payment_redirect_url", Encode.string (env.localUrl ++ "/?transaction_id={transaction_id}&payment_id={payment_id}&order_id={order_id}") )
+                , ( "payment_redirect_url", Encode.string (env.localUrl ++ "/payment?transaction_id={transaction_id}&payment_id={payment_id}&order_id={order_id}") )
                 ]
     in
         HttpUtil.post env url (Http.jsonBody body) (Http.expectJson reservationDecoder)

--- a/src/elm/Service/Ticket.elm
+++ b/src/elm/Service/Ticket.elm
@@ -77,15 +77,7 @@ receipt env emailAddress orderId =
                 , ( "order_version", Encode.int 1 )
                 ]
     in
-        Http.request
-            { method = "POST"
-            , headers = [ Http.header "Atb-Install-Id" env.installId ]
-            , url = url
-            , body = Http.jsonBody body
-            , expect = Http.expectStringResponse (\_ -> Ok ())
-            , timeout = Nothing
-            , withCredentials = False
-            }
+        HttpUtil.post env url (Http.jsonBody body) (Http.expectStringResponse (\_ -> Ok ()))
 
 
 getPaymentStatus : Environment -> Int -> Http.Request PaymentStatus

--- a/src/elm/Ui/TicketDetails.elm
+++ b/src/elm/Ui/TicketDetails.elm
@@ -2,7 +2,7 @@ module Ui.TicketDetails exposing (view, viewActivation)
 
 import Data.FareContract exposing (FareContract, TravelRight(..), TravelRightFull)
 import Data.RefData exposing (LangString(..))
-import Data.Ticket exposing (Reservation)
+import Data.Ticket exposing (Reservation, ReservationStatus(..))
 import Dict exposing (Dict)
 import Dict.Extra
 import Fragment.Icon
@@ -145,8 +145,8 @@ view shared { fareContract, open, onOpenClick, currentTime, timeZone } =
             ]
 
 
-viewActivation : Reservation -> Html msg
-viewActivation reservation =
+viewActivation : ( Reservation, ReservationStatus ) -> Html msg
+viewActivation ( reservation, status ) =
     let
         classList =
             [ ( "ui-ticketDetails", True )
@@ -159,6 +159,14 @@ viewActivation reservation =
 
         icon =
             activeReservationLoading
+
+        captureText =
+            case status of
+                Captured ->
+                    "Betaling godkjent. Henter billett..."
+
+                NotCaptured ->
+                    "Prosesseres... ikke gyldig enda."
     in
         Ui.TextContainer.primary
             [ H.section
@@ -168,7 +176,7 @@ viewActivation reservation =
                         [ H.div [ A.class "ui-ticketDetails__headerButton__icon" ]
                             [ icon ]
                         , H.div [ A.class "ui-ticketDetails__headerButton__title" ]
-                            [ H.text "Utsteder billett..." ]
+                            [ H.text captureText ]
                         ]
                     ]
                 , H.div [ A.classList classListMetadata ]

--- a/src/elm/Ui/TicketDetails.elm
+++ b/src/elm/Ui/TicketDetails.elm
@@ -2,7 +2,7 @@ module Ui.TicketDetails exposing (view, viewActivation)
 
 import Data.FareContract exposing (FareContract, TravelRight(..), TravelRightFull)
 import Data.RefData exposing (LangString(..))
-import Data.Ticket exposing (ActiveReservation)
+import Data.Ticket exposing (Reservation)
 import Dict exposing (Dict)
 import Dict.Extra
 import Fragment.Icon
@@ -145,8 +145,8 @@ view shared { fareContract, open, onOpenClick, currentTime, timeZone } =
             ]
 
 
-viewActivation : ActiveReservation -> Html msg
-viewActivation activeReservation =
+viewActivation : Reservation -> Html msg
+viewActivation reservation =
     let
         classList =
             [ ( "ui-ticketDetails", True )
@@ -159,14 +159,6 @@ viewActivation activeReservation =
 
         icon =
             activeReservationLoading
-
-        reservation =
-            activeReservation.reservation
-
-        paymentType =
-            activeReservation.paymentStatus
-                |> Maybe.map .paymentType
-                |> Maybe.withDefault ""
     in
         Ui.TextContainer.primary
             [ H.section
@@ -183,9 +175,6 @@ viewActivation activeReservation =
                     [ Ui.LabelItem.viewCompact
                         "Ordre-ID"
                         [ H.text reservation.orderId ]
-                    , Ui.LabelItem.viewCompact
-                        "Betales med"
-                        [ H.text paymentType ]
                     ]
                 ]
             ]

--- a/src/elm/Ui/TicketDetails.elm
+++ b/src/elm/Ui/TicketDetails.elm
@@ -47,7 +47,7 @@ view shared { fareContract, open, onOpenClick, currentTime, timeZone } =
             Time.posixToMillis currentTime
 
         isCurrentlyActive =
-            fareContract.validFrom < now
+            fareContract.validFrom <= now
 
         classList =
             [ ( "ui-ticketDetails", True )
@@ -356,8 +356,13 @@ viewValidity from to posixNow timeZone =
         now =
             Time.posixToMillis posixNow
     in
-        if from > now then
+        if from > now + (3 * 60 * 60 * 1000) then
+            -- Active in over 3 hours, show absolute time.
             H.text <| "Gyldig fra " ++ TimeUtil.toFullHumanized timeZone (Time.millisToPosix from)
+
+        else if from > now then
+            -- If active within 3 hours, show relative time
+            H.text <| "Gyldig om " ++ timeFormat ((from - now) // 1000) "" "kort tid"
 
         else if now > to then
             H.text <| timeAgoFormat <| (now - to) // 1000

--- a/src/elm/Util/PhoneNumber.elm
+++ b/src/elm/Util/PhoneNumber.elm
@@ -1,6 +1,17 @@
-module Util.PhoneNumber exposing (format)
+module Util.PhoneNumber exposing (format, withoutCountryCode)
 
 import Util.NumberFormater as NF
+
+
+withoutCountryCode : String -> String
+withoutCountryCode phone =
+    if String.startsWith "+" phone then
+        -- NOTE: This isn't ideal permanently. If supporting multiple country codes, we should
+        -- check for complete list as some are 3 digits.
+        String.dropLeft 3 phone
+
+    else
+        phone
 
 
 format : String -> String
@@ -10,7 +21,7 @@ format phone =
             String.left 3 phone
 
         actualPhone =
-            String.replace countryCode "" phone
+            withoutCountryCode phone
     in
         NF.formatString
             [ NF.Str countryCode

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -379,8 +379,8 @@ app.ports.onboardingDone.subscribe(() => {
     }, 500);
 });
 
-app.ports.openWindow.subscribe((url) => {
-    window.open(url);
+app.ports.navigateTo.subscribe((url) => {
+    window.location.assign(url);
 });
 
 if (app.ports.convertTime) {


### PR DESCRIPTION
Skriver om kjøpsflyten til å være i samme vindu og håndtere flere caser. Gjort noen endringer i tilstandshåndtering for kjøpsvinduet. Det gjør det mer stabilt og åpner for å refreshe siden. Men når man refresher, eller navigerer tilbake fra kjøpsvindu (vipps/nets) så er state resatt. For å løse det må vi til med noe ala localstorage eller på selve brukeren med reserverte kjøp. Men det blir ikke i scope for denne oppgaven.


## Mulige fremtidige forbedringer

- Lagre i local state (localstorage) ved reservation i kjøpsskjerm for når det sendes tilbake med feil eller navigerer tilbake til siden så huskes det aktive kjøpet uten å måtte gjøre det på nytt.


Fixes #107 