### PR TITLE
Legger til informasjon under innlogging som peker til onboardings info

### DIFF
--- a/src/elm/Page/History.elm
+++ b/src/elm/Page/History.elm
@@ -116,7 +116,7 @@ update msg env model =
         ReceiveReceipt orderId _ ->
             -- TODO: Show error
             PageUpdater.init { model | sendingReceipt = List.Extra.remove orderId model.sendingReceipt }
-                |> ("Kvitteringen ble sendt til din e-post."
+                |> (H.text "Kvitteringen ble sendt til din e-post."
                         |> Message.Valid
                         |> Message.message
                         |> (\s -> Notification.setContent s Notification.init)

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -177,6 +177,12 @@ viewLogin _ model =
                     |> T.setPlaceholder "Logg inn med telefonnummeret ditt"
                     |> T.view
                 ]
+            , H.p []
+                [ H.text "I betaperioden har nettbutikken spesielle begrenseninger og forutsetninger. Gjør deg kjent med disse før du logger inn. "
+                , H.a [ A.href "https://beta.atb.no/onboarding/nettbutikk", A.title "Les mer om begrensninger og forutsetninger for piloten på AtBeta" ] [ H.text "Begrensninger og forutsetninger." ]
+                ]
+                |> Message.Warning
+                |> Message.message
             , B.init "Send engangspassord"
                 |> B.setIcon (Just Icon.rightArrow)
                 |> B.setType "submit"

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -79,7 +79,7 @@ update msg _ model =
 
         Resend ->
             updateLogin model
-                |> ("Sendt ny forespørsel etter engangspassord."
+                |> (H.text "Sendt ny forespørsel etter engangspassord."
                         |> Message.Valid
                         |> Message.message
                         |> (\s -> Notification.setContent s Notification.init)

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -179,7 +179,7 @@ viewLogin _ model =
                 ]
             , H.p []
                 [ H.text "I betaperioden har nettbutikken spesielle begrenseninger og forutsetninger. Gjør deg kjent med disse før du logger inn. "
-                , H.a [ A.href "https://beta.atb.no/onboarding/nettbutikk", A.title "Les mer om begrensninger og forutsetninger for piloten på AtBeta" ] [ H.text "Begrensninger og forutsetninger." ]
+                , H.a [ A.href "https://beta.atb.no/onboarding/nettbutikk", A.target "_blank", A.title "Les mer om begrensninger og forutsetninger for piloten på AtBeta" ] [ H.text "Begrensninger og forutsetninger (åpner ny side)." ]
                 ]
                 |> Message.Warning
                 |> Message.message

--- a/src/elm/Page/Shop.elm
+++ b/src/elm/Page/Shop.elm
@@ -298,7 +298,7 @@ update msg env model shared =
                                 "Kunne ikke laste inn billettinformasjon. Prøv igjen."
                         in
                             PageUpdater.init { model | offers = Failed errorMessage }
-                                |> addGlobalNotification (Message.Error errorMessage)
+                                |> addGlobalNotification (Message.Error <| H.text errorMessage)
 
             BuyOffers paymentType ->
                 case model.offers of
@@ -339,7 +339,7 @@ update msg env model shared =
                                 "Fikk ikke reservert billett. Prøv igjen."
                         in
                             PageUpdater.init { model | reservation = Failed errorMessage }
-                                |> addGlobalNotification (Message.Error errorMessage)
+                                |> addGlobalNotification (Message.Error <| H.text errorMessage)
 
             CloseShop ->
                 PageUpdater.fromPair ( model, TaskUtil.doTask ResetState )

--- a/src/elm/Ui/Message.elm
+++ b/src/elm/Ui/Message.elm
@@ -20,11 +20,11 @@ import Html as H exposing (Html)
 import Html.Attributes as A
 
 
-type UserStatus
-    = Warning String
-    | Info String
-    | Valid String
-    | Error String
+type UserStatus msg
+    = Warning (Html msg)
+    | Info (Html msg)
+    | Valid (Html msg)
+    | Error (Html msg)
 
 
 type Border
@@ -34,7 +34,7 @@ type Border
     | NoBorder
 
 
-statusToClass : UserStatus -> String
+statusToClass : UserStatus msg -> String
 statusToClass status =
     case status of
         Warning _ ->
@@ -50,7 +50,7 @@ statusToClass status =
             "ui-message--info"
 
 
-statusToIcon : UserStatus -> Html msg
+statusToIcon : UserStatus msg -> Html msg
 statusToIcon status =
     case status of
         Warning _ ->
@@ -66,7 +66,7 @@ statusToIcon status =
             Icon.info
 
 
-stringOfStatus : UserStatus -> String
+stringOfStatus : UserStatus msg -> Html msg
 stringOfStatus status =
     case status of
         Warning text ->
@@ -90,7 +90,7 @@ type alias Message =
     }
 
 
-messageWithOptions : Message -> UserStatus -> Html msg
+messageWithOptions : Message -> UserStatus msg -> Html msg
 messageWithOptions options statusType =
     let
         statusClass =
@@ -106,7 +106,7 @@ messageWithOptions options statusType =
             ]
 
         text =
-            H.text <| stringOfStatus statusType
+            stringOfStatus statusType
 
         icon =
             statusToIcon statusType
@@ -126,29 +126,29 @@ defaultOption =
     }
 
 
-message : UserStatus -> Html msg
+message : UserStatus msg -> Html msg
 message =
     messageWithOptions defaultOption
 
 
 infoWithOptions : Message -> String -> Html msg
 infoWithOptions opts text =
-    messageWithOptions opts (Info text)
+    messageWithOptions opts (Info <| H.text text)
 
 
 warningWithOptions : Message -> String -> Html msg
 warningWithOptions opts text =
-    messageWithOptions opts (Warning text)
+    messageWithOptions opts (Warning <| H.text text)
 
 
 validWithOptions : Message -> String -> Html msg
 validWithOptions opts text =
-    messageWithOptions opts (Valid text)
+    messageWithOptions opts (Valid <| H.text text)
 
 
 errorWithOptions : Message -> String -> Html msg
 errorWithOptions opts text =
-    messageWithOptions opts (Error text)
+    messageWithOptions opts (Error <| H.text text)
 
 
 info : String -> Html msg


### PR DESCRIPTION
Se kommentar om ny flyt i #152. Her gjør vi det enkelt med å ha egen informasjonsside på AtBeta og lenker til den fra innloggingen. Se også https://github.com/AtB-AS/atbeta/pull/39

Fixes #152


![Screenshot 2021-05-31 at 09 51 47](https://user-images.githubusercontent.com/606374/120159754-d33bec00-c1f5-11eb-90f8-fcde24f91d3e.png)
