### PR TITLE
feat: adds role alert for all messages

### DIFF
--- a/src/elm/Ui/Message.elm
+++ b/src/elm/Ui/Message.elm
@@ -113,7 +113,7 @@ messageWithOptions options statusType =
     in
         H.div [ A.classList classList ]
             [ icon
-            , H.div [ A.class "ui-message__content" ] [ text ]
+            , H.div [ A.class "ui-message__content", A.attribute "role" "alert" ] [ text ]
             ]
 
 

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -803,9 +803,14 @@ a.ui-button--link,
 }
 
 .ui-notifications {
-    position: absolute;
+    position: fixed;
     top: var(--spacings-xLarge);
-    right: var(--spacings-xLarge);
+    right: 0;
+
+    padding: var(--spacings-medium);
+    width: 100%;
+
+    max-width: 25rem;
 
     max-height: 70vh;
     overflow: auto;


### PR DESCRIPTION
Prøver meg på en endring her jeg ikke helt greier å stabilt skjønne konsekvensene av i forskjellige scenario. Vært fint å testet på forskjellige enheter i forskjellige bruksområder.

Her er en endring som setter alle meldinger (meldingsbokser) til en alert for skjermlesere. I praksis gjør det at den blir lest opp nå den dukker opp. Men jeg vet ikke om all vår bruk gjør at det blir korrekt. Så vært fint med test i voice over, talkback osv.