### PR TITLE
feat: adds initial reusable summary subpage

### DIFF
--- a/src/elm/Fragment/Icon.elm
+++ b/src/elm/Fragment/Icon.elm
@@ -67,17 +67,17 @@ wrapper size iconHtml =
 
 viewLarge : Html msg -> Html msg
 viewLarge =
-    List.singleton >> H.div [ A.class "ui-icon ui-icon--large" ]
+    List.singleton >> H.span [ A.class "ui-icon ui-icon--large" ]
 
 
 viewLargeMonochrome : Html msg -> Html msg
 viewLargeMonochrome =
-    List.singleton >> H.div [ A.class "ui-icon ui-icon--large ui-icon--monochrome" ]
+    List.singleton >> H.span [ A.class "ui-icon ui-icon--large ui-icon--monochrome" ]
 
 
 viewMonochrome : Html msg -> Html msg
 viewMonochrome =
-    List.singleton >> H.div [ A.class "ui-icon ui-icon--monochrome" ]
+    List.singleton >> H.span [ A.class "ui-icon ui-icon--monochrome" ]
 
 
 checkmark : Html msg

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -20,8 +20,8 @@ import Page.History as HistoryPage
 import Page.Login as LoginPage
 import Page.Onboarding as OnboardingPage
 import Page.Overview as OverviewPage
-import Page.Shop as ShopPage
-import Page.ShopCarnet as ShopCarnetPage
+import Page.Shop.Carnet as ShopCarnetPage
+import Page.Shop.Period as ShopPage
 import Page.VerifyUser as VerifyUserPage
 import PageUpdater exposing (PageUpdater)
 import Route exposing (LoginMethodPath(..), Route(..))

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -659,7 +659,6 @@ viewPage model =
             Just Route.Shop ->
                 ShopPage.view env model.appInfo shared model.shop model.route
                     |> H.map ShopMsg
-                    |> wrapSubPage "Kjøp ny periodebillett"
 
             Just Route.ShopCarnet ->
                 ShopCarnetPage.view env model.appInfo shared model.shopCarnet model.route

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -132,7 +132,7 @@ setRouteInternal initialRoute maybeRoute model =
                     TaskUtil.doTask <| ShopMsg ShopPage.OnLeavePage
 
                 ( Just _, Just Route.ShopCarnet ) ->
-                    TaskUtil.doTask <| ShopMsg ShopPage.OnLeavePage
+                    TaskUtil.doTask <| ShopCarnetMsg ShopCarnetPage.OnLeavePage
 
                 _ ->
                     Cmd.none
@@ -664,7 +664,6 @@ viewPage model =
             Just Route.ShopCarnet ->
                 ShopCarnetPage.view env model.appInfo shared model.shopCarnet model.route
                     |> H.map ShopCarnetMsg
-                    |> wrapSubPage "Kjøp nytt klippekort"
 
             Just Route.History ->
                 HistoryPage.view env model.appInfo shared model.history model.route

--- a/src/elm/Page/Shop/Carnet.elm
+++ b/src/elm/Page/Shop/Carnet.elm
@@ -10,7 +10,6 @@ import Html as H exposing (Html)
 import Html.Attributes as A
 import Html.Events as E
 import Http
-import Notification
 import Page.Shop.CommonViews as Common
 import Page.Shop.Summary as SummaryPage
 import Page.Shop.Utils as Utils exposing (TravelDateTime(..))
@@ -24,7 +23,6 @@ import Task
 import Time
 import Ui.Button exposing (ThemeColor(..))
 import Ui.Group
-import Ui.Message as Message
 import Ui.PageHeader as PH
 import Ui.Section as Section
 import Util.Status exposing (Status(..))
@@ -300,6 +298,7 @@ view _ _ shared model _ =
                     [ PH.init
                         |> PH.setTitle (Just "Kjøp nytt klippekort")
                         |> PH.setBackButton (Just ( "Avbryt", E.onClick CloseShop ))
+                        |> PH.setBackIcon Icon.cross
                         |> PH.view
                     , H.div [ A.class "page" ]
                         [ Section.view

--- a/src/elm/Page/Shop/Carnet.elm
+++ b/src/elm/Page/Shop/Carnet.elm
@@ -1,7 +1,7 @@
-module Page.Shop exposing (Model, Msg(..), init, subscriptions, update, view)
+module Page.Shop.Carnet exposing (Model, Msg(..), init, subscriptions, update, view)
 
 import Base exposing (AppInfo)
-import Data.RefData exposing (FareProduct, LangString(..), UserType(..))
+import Data.RefData exposing (LangString(..), ProductType(..), UserType(..))
 import Data.Ticket exposing (Offer, PaymentType(..), Reservation)
 import Environment exposing (Environment)
 import Fragment.Icon as Icon
@@ -9,30 +9,26 @@ import GlobalActions as GA
 import Html as H exposing (Html)
 import Html.Attributes as A
 import Html.Events as E
-import Html.Extra
 import Http
 import Notification
-import Page.Shop.Common as Common exposing (TravelDateTime(..))
+import Page.Shop.CommonViews as Common
 import Page.Shop.Summary as SummaryPage
+import Page.Shop.Utils as Utils exposing (TravelDateTime(..))
 import PageUpdater exposing (PageUpdater)
 import Process
 import Route exposing (Route)
-import Service.Misc as MiscService
 import Service.Ticket as TicketService
 import Set
 import Shared exposing (Shared)
 import Task
-import Time exposing (Posix)
+import Time
+import Ui.Button exposing (ThemeColor(..))
 import Ui.Group
-import Ui.Input.Radio as Radio
-import Ui.Input.Text as Text
 import Ui.Message as Message
 import Ui.PageHeader as PH
 import Ui.Section as Section
-import Util.Func as Func
 import Util.Status exposing (Status(..))
 import Util.Task as TaskUtil
-import Util.Time as TimeUtil
 
 
 type Msg
@@ -42,17 +38,10 @@ type Msg
     | FetchOffers
     | ReceiveOffers (Result Http.Error (List Offer))
     | CloseShop
-    | SetProduct String Bool
     | SetFromZone String
     | SetToZone String
     | SetUser UserType Bool
     | ShowView MainView
-    | SetTime String
-    | SetDate String
-    | UpdateNow Time.Posix
-    | UpdateZone Time.Zone
-    | GetIsoTime String
-    | SetTravelDateTime TravelDateTime
     | CloseSummary
     | GoToSummary
     | SummarySubMsg SummaryPage.Msg
@@ -60,8 +49,6 @@ type Msg
 
 type MainView
     = Travelers
-    | Duration
-    | Start
     | Zones
     | None
 
@@ -74,12 +61,9 @@ type alias Model =
     , offers : Status (List Offer)
     , reservation : Status Reservation
     , mainView : MainView
-    , travelDateTime : TravelDateTime
-    , now : Posix
-    , inputTravelDate : String
-    , inputTravelTime : String
-    , timeZone : Time.Zone
     , summary : Maybe SummaryPage.Model
+    , timeZone : Time.Zone
+    , travelDateTime : TravelDateTime
     }
 
 
@@ -91,18 +75,12 @@ init =
       , users = [ ( UserTypeAdult, 1 ) ]
       , offers = NotLoaded
       , reservation = NotLoaded
-      , mainView = Duration
-      , travelDateTime = TravelNow
-      , now = Time.millisToPosix 0
-      , inputTravelDate = ""
-      , inputTravelTime = ""
-      , timeZone = Time.utc
+      , mainView = Travelers
       , summary = Nothing
+      , travelDateTime = TravelNow
+      , timeZone = Time.utc
       }
-    , Cmd.batch
-        [ TaskUtil.doTask FetchOffers
-        , Task.perform UpdateZone Time.here
-        ]
+    , TaskUtil.doTask FetchOffers
     )
 
 
@@ -130,12 +108,6 @@ update msg env model shared =
             OnLeavePage ->
                 PageUpdater.init { model | summary = Nothing }
 
-            SetProduct product _ ->
-                PageUpdater.fromPair
-                    ( { model | product = Just product, users = maybeResetUsers shared product model.users }
-                    , TaskUtil.doTask FetchOffers
-                    )
-
             SetFromZone zone ->
                 PageUpdater.fromPair
                     ( { model | fromZone = Just zone }
@@ -151,45 +123,6 @@ update msg env model shared =
             SetUser userType _ ->
                 PageUpdater.fromPair
                     ( { model | users = [ ( userType, 1 ) ] }
-                    , TaskUtil.doTask FetchOffers
-                    )
-
-            SetTravelDateTime (TravelFuture maybeFuture) ->
-                case maybeFuture of
-                    Nothing ->
-                        let
-                            travelDate =
-                                if String.isEmpty model.inputTravelDate then
-                                    TimeUtil.toIsoDate model.timeZone model.now
-
-                                else
-                                    model.inputTravelDate
-
-                            travelTime =
-                                if String.isEmpty model.inputTravelTime then
-                                    TimeUtil.toHoursAndMinutes model.timeZone <| TimeUtil.addHours 1 model.now
-
-                                else
-                                    model.inputTravelTime
-                        in
-                            PageUpdater.fromPair
-                                ( { model
-                                    | travelDateTime = TravelFuture Nothing
-                                    , inputTravelDate = travelDate
-                                    , inputTravelTime = travelTime
-                                  }
-                                , MiscService.convertTime ( travelDate, travelTime )
-                                )
-
-                    future ->
-                        PageUpdater.fromPair
-                            ( { model | travelDateTime = TravelFuture <| future }
-                            , TaskUtil.doTask FetchOffers
-                            )
-
-            SetTravelDateTime TravelNow ->
-                PageUpdater.fromPair
-                    ( { model | travelDateTime = TravelNow }
                     , TaskUtil.doTask FetchOffers
                     )
 
@@ -210,11 +143,15 @@ update msg env model shared =
                                 _ ->
                                     Nothing
 
+                        availableProducts =
+                            shared.fareProducts
+                                |> List.filter (.type_ >> (==) ProductTypeCarnet)
+
                         ( firstZone, defaultProduct ) =
-                            defaultDerivedData shared
+                            Utils.defaultDerivedData shared availableProducts
 
                         dataNotLoadedYet =
-                            List.isEmpty shared.availableFareProducts && List.isEmpty shared.tariffZones
+                            List.isEmpty availableProducts && List.isEmpty shared.tariffZones
 
                         newProduct =
                             Maybe.withDefault defaultProduct model.product
@@ -224,14 +161,6 @@ update msg env model shared =
 
                         newToZone =
                             Maybe.withDefault firstZone model.toZone
-
-                        travelTime =
-                            case model.travelDateTime of
-                                TravelFuture (Just time) ->
-                                    Just time
-
-                                _ ->
-                                    Nothing
                     in
                         if dataNotLoadedYet then
                             PageUpdater.fromPair
@@ -253,7 +182,7 @@ update msg env model shared =
                                     newFromZone
                                     newToZone
                                     model.users
-                                    travelTime
+                                    Nothing
                                 )
 
             ReceiveOffers result ->
@@ -276,30 +205,6 @@ update msg env model shared =
             ShowView mainView ->
                 PageUpdater.init (toggleShowMainView model mainView)
 
-            SetDate date ->
-                PageUpdater.fromPair
-                    ( { model | inputTravelDate = date }
-                    , MiscService.convertTime ( date, model.inputTravelTime )
-                    )
-
-            SetTime time ->
-                PageUpdater.fromPair
-                    ( { model | inputTravelTime = time }
-                    , MiscService.convertTime ( model.inputTravelDate, time )
-                    )
-
-            UpdateNow now ->
-                PageUpdater.init { model | now = now }
-
-            UpdateZone zone ->
-                PageUpdater.init { model | timeZone = zone }
-
-            GetIsoTime isoTime ->
-                PageUpdater.fromPair
-                    ( model
-                    , TaskUtil.doTask <| SetTravelDateTime <| TravelFuture (Just isoTime)
-                    )
-
             CloseSummary ->
                 PageUpdater.init { model | summary = Nothing }
 
@@ -314,7 +219,8 @@ update msg env model shared =
                                             { productId = Maybe.withDefault "" model.product
                                             , fromZoneId = Maybe.withDefault "" model.fromZone
                                             , toZoneId = Maybe.withDefault "" model.toZone
-                                            , travelDate = Nothing
+                                            , travelDate = model.travelDateTime
+                                            , timeZone = model.timeZone
                                             }
                                             offers
                             }
@@ -332,44 +238,6 @@ update msg env model shared =
                             |> PageUpdater.map (\newModel -> { model | summary = Just newModel }) SummarySubMsg
 
 
-defaultDerivedData : Shared -> ( String, String )
-defaultDerivedData shared =
-    let
-        firstZone =
-            shared.tariffZones
-                |> List.sortWith
-                    (\a b ->
-                        case ( a.name, b.name ) of
-                            ( LangString _ nameA, LangString _ nameB ) ->
-                                compare nameA nameB
-                    )
-                |> List.head
-                |> Maybe.map .id
-                |> Maybe.withDefault ""
-
-        defaultProduct =
-            shared.availableFareProducts
-                |> List.head
-                |> Maybe.map .id
-                |> Maybe.withDefault ""
-    in
-        ( firstZone, defaultProduct )
-
-
-maybeResetUsers : Shared -> String -> List ( UserType, Int ) -> List ( UserType, Int )
-maybeResetUsers shared product users =
-    let
-        data =
-            users
-                |> List.filter (Tuple.first >> Func.flip List.member (Common.findLimitations product shared.productLimitations))
-    in
-        if List.isEmpty data then
-            [ ( UserTypeAdult, 1 ) ]
-
-        else
-            data
-
-
 toggleShowMainView : Model -> MainView -> Model
 toggleShowMainView model mainView =
     { model
@@ -385,11 +253,15 @@ toggleShowMainView model mainView =
 view : Environment -> AppInfo -> Shared -> Model -> Maybe Route -> Html Msg
 view _ _ shared model _ =
     let
+        availableProducts =
+            shared.fareProducts
+                |> List.filter (.type_ >> (==) ProductTypeCarnet)
+
         ( defaultZone, defaultProduct ) =
-            defaultDerivedData shared
+            Utils.defaultDerivedData shared availableProducts
 
         summary =
-            Common.modelSummary ( defaultZone, defaultProduct ) shared model
+            Utils.modelSummary ( defaultZone, defaultProduct ) shared model
 
         errorMessage =
             case model.offers of
@@ -435,7 +307,7 @@ view _ _ shared model _ =
             _ ->
                 H.div []
                     [ PH.init
-                        |> PH.setTitle (Just "Kjøp nytt periodebillett")
+                        |> PH.setTitle (Just "Kjøp nytt klippekort")
                         |> PH.setBackButton (Just ( "Avbryt", E.onClick CloseShop ))
                         |> PH.view
                     , H.div [ A.class "page" ]
@@ -452,16 +324,16 @@ view _ _ shared model _ =
                                 }
                                 []
                             , Ui.Group.view
-                                { title = "Billettype"
-                                , icon = Icon.duration
-                                , value = summary.duration
-                                , open = model.mainView == Duration
-                                , readonly = False
-                                , onOpenClick = Just (ShowView Duration)
-                                , id = "varighet"
-                                , editTextSuffix = "varighet"
+                                { title = "Antall billetter"
+                                , icon = Icon.tickets
+                                , value = summary.product
+                                , open = False
+                                , readonly = True
+                                , onOpenClick = Nothing
+                                , id = "product"
+                                , editTextSuffix = "antall"
                                 }
-                                [ viewProducts model defaultProduct shared.availableFareProducts ]
+                                []
                             , Ui.Group.view
                                 { title = "Reisende"
                                 , icon = Icon.bus
@@ -477,17 +349,6 @@ view _ _ shared model _ =
                                 }
                                 [ Common.viewUserProfiles defaultProduct model SetUser shared ]
                             , Ui.Group.view
-                                { title = "Gyldig fra og med"
-                                , icon = Icon.ticket
-                                , value = summary.start
-                                , open = model.mainView == Start
-                                , readonly = False
-                                , onOpenClick = Just (ShowView Start)
-                                , id = "duration"
-                                , editTextSuffix = "tid"
-                                }
-                                (viewStart model)
-                            , Ui.Group.view
                                 { title = "Soner"
                                 , icon = Icon.map
                                 , value = summary.zones
@@ -499,88 +360,17 @@ view _ _ shared model _ =
                                 }
                                 [ Common.viewZones model defaultZone shared.tariffZones SetFromZone SetToZone ]
                             ]
-                        , Common.viewSummary shared model disableButtons GoToSummary
+                        , H.div []
+                            [ Common.viewSummary shared model disableButtons GoToSummary
+                            ]
                         ]
                     ]
 
 
-langString : LangString -> String
-langString (LangString _ value) =
-    value
-
-
-viewStart : Model -> List (Html Msg)
-viewStart model =
-    let
-        isFutureSelected =
-            model.travelDateTime /= TravelNow
-    in
-        [ Radio.viewGroup "Velg avreisetid"
-            [ Radio.init "travel-now"
-                |> Radio.setTitle "Kjøpstidspunkt"
-                |> Radio.setName "traveltime"
-                |> Radio.setChecked (not isFutureSelected)
-                |> Radio.setOnCheck (Just <| \_ -> SetTravelDateTime TravelNow)
-                |> Radio.view
-            , Radio.init "travel-future"
-                |> Radio.setTitle "Velg dato og tid"
-                |> Radio.setName "traveltime"
-                |> Radio.setChecked isFutureSelected
-                |> Radio.setOnCheck (Just <| \_ -> SetTravelDateTime <| TravelFuture Nothing)
-                |> Radio.view
-            ]
-        , Html.Extra.viewIf isFutureSelected <|
-            Section.viewHorizontalGroup
-                [ Text.init "date"
-                    |> Text.setTitle (Just "Dato")
-                    |> Text.setOnInput (Just SetDate)
-                    |> Text.setAttributes [ A.min <| TimeUtil.toIsoDate model.timeZone model.now ]
-                    |> Text.setType "date"
-                    |> Text.setValue (Just model.inputTravelDate)
-                    |> Text.view
-                , Text.init "time"
-                    |> Text.setTitle (Just "Tid")
-                    |> Text.setOnInput (Just SetTime)
-                    |> Text.setAttributes
-                        [ A.min <| TimeUtil.toHoursAndMinutes model.timeZone model.now ]
-                    |> Text.setType "time"
-                    |> Text.setValue (Just model.inputTravelTime)
-                    |> Text.view
-                ]
-        ]
-
-
-viewProducts : Model -> String -> List FareProduct -> Html Msg
-viewProducts model defaultProduct products =
-    products
-        |> List.map (viewProduct model defaultProduct)
-        |> Radio.viewGroup "Velg billettype"
-
-
-viewProduct : Model -> String -> FareProduct -> Html Msg
-viewProduct model defaultProduct product =
-    let
-        selectedProduct =
-            Maybe.withDefault defaultProduct model.product
-
-        isCurrent =
-            selectedProduct == product.id
-    in
-        Radio.init product.id
-            |> Radio.setTitle (langString product.name)
-            |> Radio.setName "product"
-            |> Radio.setChecked isCurrent
-            |> Radio.setOnCheck (Just <| SetProduct product.id)
-            |> Radio.view
-
-
 subscriptions : Model -> Sub Msg
 subscriptions _ =
-    Sub.batch
-        [ MiscService.convertedTime GetIsoTime
-        , Time.every 1000 UpdateNow
-        , SummaryPage.subscriptions |> Sub.map SummarySubMsg
-        ]
+    SummaryPage.subscriptions
+        |> Sub.map SummarySubMsg
 
 
 

--- a/src/elm/Page/Shop/Common.elm
+++ b/src/elm/Page/Shop/Common.elm
@@ -1,0 +1,152 @@
+module Page.Shop.Common exposing (CommonModel, TravelDateTime(..), viewSummary, viewZones)
+
+import Data.RefData exposing (LangString(..), TariffZone)
+import Data.Ticket exposing (Offer)
+import Fragment.Icon as Icon
+import Html as H exposing (Html)
+import Html.Attributes as A
+import Page.Shop.Summary as SummaryPage
+import Shared exposing (Shared)
+import Ui.Button as B exposing (ThemeColor(..))
+import Ui.Input.Select as Select
+import Ui.LabelItem
+import Ui.LoadingText
+import Ui.Message as Message
+import Ui.Section as Section
+import Util.Format
+import Util.Func as Func
+import Util.Status exposing (Status(..))
+
+
+type TravelDateTime
+    = TravelNow
+    | TravelFuture (Maybe String)
+
+
+type alias CommonModel a =
+    { a
+        | offers : Status (List Offer)
+        , product : Maybe String
+        , fromZone : Maybe String
+        , toZone : Maybe String
+        , travelDateTime : TravelDateTime
+    }
+
+
+viewSummary : Shared -> CommonModel a -> Bool -> msg -> Html msg
+viewSummary shared model disableButtons onToSummaryClick =
+    let
+        emptyOffers =
+            case model.offers of
+                Loaded offers ->
+                    List.isEmpty offers
+
+                _ ->
+                    False
+
+        summary =
+            case model.offers of
+                Loaded offers ->
+                    Just <|
+                        SummaryPage.makeSummary
+                            { productId = Maybe.withDefault "" model.product
+                            , fromZoneId = Maybe.withDefault "" model.fromZone
+                            , toZoneId = Maybe.withDefault "" model.toZone
+                            , travelDate = stringFromtravelDateTime model.travelDateTime
+                            }
+                            offers
+                            shared
+
+                _ ->
+                    Nothing
+    in
+        Section.init
+            |> Section.viewWithOptions
+                [ if emptyOffers then
+                    Message.warning "Finner ingen tilgjengelige billetter."
+
+                  else
+                    Section.viewPaddedItem
+                        [ Ui.LabelItem.viewHorizontal
+                            "Total:"
+                            [ H.p [ A.class "shop__summaryPrice" ]
+                                [ summary
+                                    |> Maybe.map .totalPrice
+                                    |> Maybe.map (Func.flip Util.Format.float 2)
+                                    |> Maybe.map H.text
+                                    |> Maybe.withDefault (Ui.LoadingText.view "1.6875rem" "5rem")
+                                , H.small [] [ H.text "kr" ]
+                                ]
+                            ]
+                        , Ui.LabelItem.viewHorizontal "Hvorav mva:"
+                            [ summary
+                                |> Maybe.map .totalVat
+                                |> Maybe.map (Func.flip Util.Format.float 2)
+                                |> Maybe.map (Func.flip (++) " kr")
+                                |> Maybe.map H.text
+                                |> Maybe.withDefault (Ui.LoadingText.view "1rem" "3rem")
+                            ]
+                        ]
+                , B.init "Gå til oppsummering"
+                    |> B.setDisabled disableButtons
+                    |> B.setIcon (Just <| Icon.viewMonochrome Icon.rightArrow)
+                    |> B.setOnClick (Just onToSummaryClick)
+                    |> B.primary Primary_2
+                ]
+
+
+viewZones : CommonModel a -> String -> List TariffZone -> (String -> msg) -> (String -> msg) -> Html msg
+viewZones model defaultZone zones onFromZoneSelected onToZoneSelected =
+    let
+        sortedZones =
+            List.sortWith
+                (\a b ->
+                    case ( a.name, b.name ) of
+                        ( LangString _ nameA, LangString _ nameB ) ->
+                            compare nameA nameB
+                )
+                zones
+
+        selectedFromZone =
+            Maybe.withDefault defaultZone model.fromZone
+
+        selectedToZone =
+            Maybe.withDefault defaultZone model.toZone
+    in
+        Section.viewItem
+            [ Section.viewHorizontalGroup
+                [ Select.init "travelFromZone"
+                    |> Select.setTitle (Just "Avreisesone")
+                    |> Select.setOnInput (Just onFromZoneSelected)
+                    |> Select.view (List.map (viewZone selectedFromZone) sortedZones)
+                , Select.init "travelToZone"
+                    |> Select.setTitle (Just "Ankomstsone")
+                    |> Select.setOnInput (Just onToZoneSelected)
+                    |> Select.view (List.map (viewZone selectedToZone) sortedZones)
+                ]
+            , Section.viewPaddedItem [ H.p [] [ H.a [ A.href "https://atb.no/soner", A.target "_blank" ] [ H.text "Se sonekart og beskrivelser (åpner ny side)" ] ] ]
+            ]
+
+
+viewZone : String -> TariffZone -> Html msg
+viewZone current zone =
+    H.option
+        [ A.value zone.id
+        , A.selected (current == zone.id)
+        ]
+        [ H.text <| langString zone.name ]
+
+
+langString : LangString -> String
+langString (LangString _ value) =
+    value
+
+
+stringFromtravelDateTime : TravelDateTime -> Maybe String
+stringFromtravelDateTime travelDateTime =
+    case travelDateTime of
+        TravelFuture (Just time) ->
+            Just time
+
+        _ ->
+            Nothing

--- a/src/elm/Page/Shop/CommonViews.elm
+++ b/src/elm/Page/Shop/CommonViews.elm
@@ -1,14 +1,12 @@
-module Page.Shop.Common exposing (CommonModel, TravelDateTime(..), findLimitations, modelSummary, nameFromFareProduct, nameFromUserType, stringFromZone, viewSummary, viewUserProfiles, viewZones)
+module Page.Shop.CommonViews exposing (viewSummary, viewUserProfiles, viewZones)
 
-import Data.RefData exposing (FareProduct, LangString(..), Limitation, TariffZone, UserProfile, UserType(..))
-import Data.Ticket exposing (Offer)
+import Data.RefData exposing (LangString(..), TariffZone, UserProfile, UserType(..))
 import Fragment.Icon as Icon
 import Html as H exposing (Html)
 import Html.Attributes as A
-import List.Extra
 import Page.Shop.Summary as SummaryPage
+import Page.Shop.Utils as Utils exposing (CommonModel)
 import Shared exposing (Shared)
-import Time
 import Ui.Button as B exposing (ThemeColor(..))
 import Ui.Input.Radio as Radio
 import Ui.Input.Select as Select
@@ -19,24 +17,6 @@ import Ui.Section as Section
 import Util.Format
 import Util.Func as Func
 import Util.Status exposing (Status(..))
-import Util.Time as TimeUtil
-
-
-type TravelDateTime
-    = TravelNow
-    | TravelFuture (Maybe String)
-
-
-type alias CommonModel a =
-    { a
-        | offers : Status (List Offer)
-        , users : List ( UserType, Int )
-        , product : Maybe String
-        , fromZone : Maybe String
-        , toZone : Maybe String
-        , timeZone : Time.Zone
-        , travelDateTime : TravelDateTime
-    }
 
 
 viewUserProfiles : String -> CommonModel a -> (UserType -> Bool -> msg) -> Shared -> Html msg
@@ -46,7 +26,7 @@ viewUserProfiles defaultProduct model onUserSelect shared =
             Maybe.withDefault defaultProduct model.product
     in
         shared.userProfiles
-            |> List.filter (.userType >> Func.flip List.member (findLimitations product shared.productLimitations))
+            |> List.filter (.userType >> Func.flip List.member (Utils.findLimitations product shared.productLimitations))
             |> List.filter (.userType >> (/=) UserTypeAnyone)
             |> List.map (viewUserProfile model onUserSelect)
             |> Radio.viewGroup "Reisende"
@@ -58,10 +38,10 @@ viewUserProfile model onUserSelect userProfile =
         isCurrent =
             List.any (Tuple.first >> (==) userProfile.userType) model.users
     in
-        Radio.init (userTypeAsIdString userProfile.userType)
-            |> Radio.setTitle (langString userProfile.name)
+        Radio.init (Utils.userTypeAsIdString userProfile.userType)
+            |> Radio.setTitle (Utils.langString userProfile.name)
             |> Radio.setName "userprofile"
-            |> Radio.setSubtitle (Just <| langString userProfile.description)
+            |> Radio.setSubtitle (Just <| Utils.langString userProfile.description)
             |> Radio.setChecked isCurrent
             |> Radio.setOnCheck (Just <| onUserSelect userProfile.userType)
             |> Radio.view
@@ -86,7 +66,8 @@ viewSummary shared model disableButtons onToSummaryClick =
                             { productId = Maybe.withDefault "" model.product
                             , fromZoneId = Maybe.withDefault "" model.fromZone
                             , toZoneId = Maybe.withDefault "" model.toZone
-                            , travelDate = stringFromtravelDateTime model.travelDateTime
+                            , travelDate = model.travelDateTime
+                            , timeZone = model.timeZone
                             }
                             offers
                             shared
@@ -168,148 +149,4 @@ viewZone current zone =
         [ A.value zone.id
         , A.selected (current == zone.id)
         ]
-        [ H.text <| langString zone.name ]
-
-
-type alias ModelSummary =
-    { users : List ( String, Int )
-    , product : Maybe String
-    , start : Maybe String
-    , zones : Maybe String
-    , duration : Maybe String
-    }
-
-
-modelSummary : ( String, String ) -> Shared -> CommonModel a -> ModelSummary
-modelSummary ( defaultZone, defaultProduct ) shared model =
-    let
-        product =
-            Maybe.withDefault defaultProduct model.product
-    in
-        { users =
-            model.users
-                |> List.map
-                    (Tuple.mapFirst (\a -> a |> nameFromUserType shared.userProfiles |> Maybe.withDefault "-"))
-        , product = nameFromFareProduct shared.fareProducts product
-        , start = stringFromStart model
-        , zones = stringFromZone shared.tariffZones defaultZone model
-        , duration = nameFromFareProduct shared.fareProducts product
-        }
-
-
-stringFromStart : CommonModel a -> Maybe String
-stringFromStart model =
-    case model.travelDateTime of
-        TravelNow ->
-            Just "Kjøpstidspunkt"
-
-        TravelFuture (Just time) ->
-            TimeUtil.isoStringToFullHumanized model.timeZone time
-
-        _ ->
-            Nothing
-
-
-nameFromUserType : List UserProfile -> UserType -> Maybe String
-nameFromUserType profiles userType =
-    profiles
-        |> List.Extra.find (.userType >> (==) userType)
-        |> Maybe.map (.name >> langString)
-
-
-nameFromFareProduct : List FareProduct -> String -> Maybe String
-nameFromFareProduct products productId =
-    products
-        |> List.Extra.find (.id >> (==) productId)
-        |> Maybe.map (.name >> langString)
-
-
-stringFromZone : List TariffZone -> String -> CommonModel a -> Maybe String
-stringFromZone tariffZones defaultZone model =
-    let
-        findName zone =
-            tariffZones
-                |> List.Extra.find (.id >> (==) zone)
-                |> Maybe.map (.name >> langString)
-                |> Maybe.withDefault "-"
-
-        fromZoneName =
-            findName (Maybe.withDefault defaultZone model.fromZone)
-
-        toZoneName =
-            findName (Maybe.withDefault defaultZone model.toZone)
-    in
-        if model.fromZone == model.toZone then
-            Just <| "Reise i 1 sone (" ++ fromZoneName ++ ")"
-
-        else
-            Just <| "Reise fra sone " ++ fromZoneName ++ " til sone " ++ toZoneName
-
-
-langString : LangString -> String
-langString (LangString _ value) =
-    value
-
-
-stringFromtravelDateTime : TravelDateTime -> Maybe String
-stringFromtravelDateTime travelDateTime =
-    case travelDateTime of
-        TravelFuture (Just time) ->
-            Just time
-
-        _ ->
-            Nothing
-
-
-findLimitations : String -> List Limitation -> List UserType
-findLimitations productId fareProducts =
-    fareProducts
-        |> List.Extra.find (.productId >> (==) productId)
-        |> Maybe.map .limitations
-        |> Maybe.withDefault []
-
-
-userTypeAsIdString : UserType -> String
-userTypeAsIdString userType =
-    case userType of
-        UserTypeAdult ->
-            "UserTypeAdult"
-
-        UserTypeChild ->
-            "UserTypeChild"
-
-        UserTypeInfant ->
-            "UserTypeInfant"
-
-        UserTypeSenior ->
-            "UserTypeSenior"
-
-        UserTypeStudent ->
-            "UserTypeStudent"
-
-        UserTypeYoungPerson ->
-            "UserTypeYoungPerson"
-
-        UserTypeSchoolPupil ->
-            "UserTypeSchoolPupil"
-
-        UserTypeMilitary ->
-            "UserTypeMilitary"
-
-        UserTypeDisabled ->
-            "UserTypeDisabled"
-
-        UserTypeDisabledCompanion ->
-            "UserTypeDisabledCompanion"
-
-        UserTypeJobSeeker ->
-            "UserTypeJobSeeker"
-
-        UserTypeEmployee ->
-            "UserTypeEmployee"
-
-        UserTypeAnimal ->
-            "UserTypeAnimal"
-
-        UserTypeAnyone ->
-            "UserTypeAnyone"
+        [ H.text <| Utils.langString zone.name ]

--- a/src/elm/Page/Shop/Period.elm
+++ b/src/elm/Page/Shop/Period.elm
@@ -412,6 +412,7 @@ view _ _ shared model _ =
                     [ PH.init
                         |> PH.setTitle (Just "Kjøp nytt periodebillett")
                         |> PH.setBackButton (Just ( "Avbryt", E.onClick CloseShop ))
+                        |> PH.setBackIcon Icon.cross
                         |> PH.view
                     , H.div [ A.class "page" ]
                         [ Section.view

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -11,11 +11,13 @@ import Html.Extra
 import Http
 import List.Extra
 import Notification
+import Page.Shop.Utils as Utils exposing (TravelDateTime)
 import PageUpdater exposing (PageUpdater)
 import Service.Misc as MiscService
 import Service.Ticket as TicketService
 import Shared exposing (Shared)
 import Task
+import Time
 import Ui.Button as B exposing (ThemeColor(..))
 import Ui.Input.Radio as Radio
 import Ui.LabelItem as LabelItem
@@ -40,7 +42,7 @@ type alias Summary =
     , productType : ProductType
     , product : String
     , travellers : String
-    , validFrom : String
+    , validFrom : Maybe String
     , travellerData : List TravellerData
     , totalPrice : Float
     , totalVat : Float
@@ -51,7 +53,8 @@ type alias OffersQuery =
     { productId : String
     , fromZoneId : String
     , toZoneId : String
-    , travelDate : Maybe String
+    , travelDate : TravelDateTime
+    , timeZone : Time.Zone
     }
 
 
@@ -152,7 +155,7 @@ makeSummary query offers shared =
         , productType = productType
         , product = Maybe.withDefault "Ukjent" productName
         , travellers = humanizeTravellerData travellerData
-        , validFrom = Maybe.withDefault "Nå" query.travelDate
+        , validFrom = Utils.stringFromTravelDate query.travelDate query.timeZone
         , travellerData = summerizeOffers shared.userProfiles offers
         , totalPrice = price
         , totalVat = vatAmount price shared
@@ -203,7 +206,7 @@ viewTicketSection summary =
               else
                 LabelItem.viewHorizontal "Periode:" [ H.text summary.product ]
             , LabelItem.viewHorizontal "Reisende:" [ H.text summary.travellers ]
-            , LabelItem.viewHorizontal "Gyldig fra:" [ H.text summary.validFrom ]
+            , LabelItem.viewHorizontal "Gyldig fra:" [ H.text <| Maybe.withDefault "Nå" summary.validFrom ]
             ]
         ]
 

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -22,7 +22,6 @@ import Ui.LabelItem as LabelItem
 import Ui.Message
 import Ui.Section as Section
 import Util.Format
-import Util.Func
 import Util.Status exposing (Status(..))
 
 
@@ -138,6 +137,10 @@ makeSummary query offers shared =
         productName =
             nameFromFareProduct shared.fareProducts query.productId
 
+        productType =
+            nameTypeFromFareProduct shared.fareProducts query.productId
+                |> Maybe.withDefault ProductTypePeriod
+
         travellerData =
             summerizeOffers shared.userProfiles offers
 
@@ -146,7 +149,7 @@ makeSummary query offers shared =
     in
         { -- @TODO At some point when expanding to different modes, this should be updated.
           travelMode = "Buss / trikk"
-        , productType = ProductTypeCarnet
+        , productType = productType
         , product = Maybe.withDefault "Ukjent" productName
         , travellers = humanizeTravellerData travellerData
         , validFrom = Maybe.withDefault "Nå" query.travelDate
@@ -310,6 +313,13 @@ nameFromFareProduct products productId =
     products
         |> List.Extra.find (.id >> (==) productId)
         |> Maybe.map (.name >> langString)
+
+
+nameTypeFromFareProduct : List FareProduct -> String -> Maybe ProductType
+nameTypeFromFareProduct products productId =
+    products
+        |> List.Extra.find (.id >> (==) productId)
+        |> Maybe.map .type_
 
 
 nameFromProductType : ProductType -> String

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -1,0 +1,154 @@
+module Page.Shop.Summary exposing (Model, Msg, Summary, init, subscriptions, update, view)
+
+import Data.RefData exposing (UserType(..))
+import Data.Ticket exposing (Offer, PaymentType(..), Reservation)
+import Environment exposing (Environment)
+import Fragment.Icon as Icon
+import GlobalActions as GA
+import Html as H exposing (Html)
+import Html.Attributes as A
+import Http
+import Notification
+import PageUpdater exposing (PageUpdater)
+import Service.Misc as MiscService
+import Service.Ticket as TicketService
+import Shared exposing (Shared)
+import Task
+import Ui.Button as B exposing (ThemeColor(..))
+import Ui.Input.Radio as Radio
+import Ui.Message
+import Ui.Section as Section
+import Util.Status exposing (Status(..))
+
+
+type Msg
+    = BuyOffers
+    | ReceiveBuyOffers (Result Http.Error Reservation)
+    | SetPaymentType PaymentType
+
+
+type alias Summary =
+    { product : String }
+
+
+type alias Model =
+    { offers : List Offer
+    , paymentType : PaymentType
+    , reservation : Status Reservation
+    }
+
+
+init : List Offer -> Model
+init offers =
+    { offers = offers
+    , paymentType = Vipps
+    , reservation = NotLoaded
+    }
+
+
+update : Msg -> Environment -> Model -> Shared -> PageUpdater Model Msg
+update msg env model shared =
+    let
+        addGlobalNotification statusText =
+            statusText
+                |> Ui.Message.message
+                |> (\s -> Notification.setContent s Notification.init)
+                |> GA.ShowNotification
+                |> PageUpdater.addGlobalAction
+    in
+        case msg of
+            BuyOffers ->
+                let
+                    offerCounts =
+                        List.map
+                            (\offer -> ( offer.offerId, 1 ))
+                            model.offers
+
+                    phone =
+                        Maybe.map .phone shared.profile
+                in
+                    PageUpdater.fromPair
+                        ( { model | reservation = Loading Nothing }
+                        , buyOffers env phone model.paymentType offerCounts
+                        )
+
+            ReceiveBuyOffers result ->
+                case result of
+                    Ok reservation ->
+                        PageUpdater.fromPair
+                            ( { model | reservation = Loaded reservation }
+                            , MiscService.navigateTo reservation.url
+                            )
+
+                    Err _ ->
+                        let
+                            errorMessage =
+                                "Fikk ikke reservert billett. Prøv igjen."
+                        in
+                            PageUpdater.init { model | reservation = Failed errorMessage }
+                                |> addGlobalNotification (Ui.Message.Error <| H.text errorMessage)
+
+            SetPaymentType paymentType ->
+                PageUpdater.init { model | paymentType = paymentType }
+
+
+view : Shared -> Model -> Html Msg
+view _ model =
+    let
+        disableButtons =
+            case model.reservation of
+                Loading _ ->
+                    True
+
+                _ ->
+                    False
+    in
+        H.div [ A.class "page page--threeColumns" ]
+            [ Section.view
+                [ Section.viewHeader "Om billetten"
+                ]
+            , Section.view
+                [ Section.viewHeader "Pris"
+                ]
+            , Section.view
+                [ Section.viewHeader "Betaling"
+                , Section.viewLabelItem "Betalingsmetode"
+                    [ Radio.viewGroup "Betalingsmetode"
+                        [ Radio.init "vipps"
+                            |> Radio.setTitle "Vipps"
+                            |> Radio.setName "paymentType"
+                            |> Radio.setChecked (model.paymentType == Vipps)
+                            |> Radio.setOnCheck (Just <| \_ -> SetPaymentType Vipps)
+                            |> Radio.view
+                        , Radio.init "visa"
+                            |> Radio.setTitle "Bankkort"
+                            |> Radio.setName "paymentType"
+                            |> Radio.setChecked (model.paymentType == Nets)
+                            |> Radio.setOnCheck (Just <| \_ -> SetPaymentType Nets)
+                            |> Radio.view
+                        ]
+                    ]
+                , B.init "Gå til oppsummering"
+                    |> B.setDisabled disableButtons
+                    |> B.setIcon (Just <| Icon.viewMonochrome Icon.rightArrow)
+                    |> B.setOnClick (Just BuyOffers)
+                    |> B.primary Primary_2
+                ]
+            ]
+
+
+subscriptions : Sub Msg
+subscriptions =
+    Sub.none
+
+
+
+--
+
+
+buyOffers : Environment -> Maybe String -> PaymentType -> List ( String, Int ) -> Cmd Msg
+buyOffers env phone paymentType offerCounts =
+    offerCounts
+        |> TicketService.reserve env phone paymentType
+        |> Http.toTask
+        |> Task.attempt ReceiveBuyOffers

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -43,6 +43,8 @@ type alias Summary =
     , travellers : String
     , validFrom : String
     , travellerData : List TravellerData
+    , totalPrice : Float
+    , totalVat : Float
     }
 
 
@@ -125,7 +127,7 @@ view shared model =
     in
         H.div [ A.class "page page--threeColumns" ]
             [ viewTicketSection summary
-            , viewPriceSection summary.travellerData shared model
+            , viewPriceSection summary
             , viewPaymentSection model
             ]
 
@@ -138,6 +140,9 @@ makeSummary query offers shared =
 
         travellerData =
             summerizeOffers shared.userProfiles offers
+
+        price =
+            totalPrice offers
     in
         { -- @TODO At some point when expanding to different modes, this should be updated.
           travelMode = "Buss / trikk"
@@ -146,6 +151,8 @@ makeSummary query offers shared =
         , travellers = humanizeTravellerData travellerData
         , validFrom = Maybe.withDefault "Nå" query.travelDate
         , travellerData = summerizeOffers shared.userProfiles offers
+        , totalPrice = price
+        , totalVat = vatAmount price shared
         }
 
 
@@ -198,25 +205,24 @@ viewTicketSection summary =
         ]
 
 
-viewPriceSection : List TravellerData -> Shared -> Model -> Html Msg
-viewPriceSection travellerData shared model =
+viewPriceSection : Summary -> Html Msg
+viewPriceSection summary =
     let
         price =
-            totalPrice model.offers
+            Util.Format.float summary.totalPrice 2
 
         vat =
-            vatAmount price shared
-                |> Util.Func.flip Util.Format.float 2
+            Util.Format.float summary.totalVat 2
     in
         Section.view
             [ Section.viewHeader "Pris"
             , Section.viewPaddedItem
-                (List.map viewTravellerData travellerData
+                (List.map viewTravellerData summary.travellerData
                     ++ [ H.hr [ A.class "shopPage__separator" ] []
                        , LabelItem.viewHorizontal
                             "Total:"
                             [ H.p [ A.class "shop__summaryPrice" ]
-                                [ price |> Util.Func.flip Util.Format.float 2 |> H.text
+                                [ H.text price
                                 , H.small [] [ H.text "kr" ]
                                 ]
                             ]

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -112,23 +112,21 @@ view _ model =
                 ]
             , Section.view
                 [ Section.viewHeader "Betaling"
-                , Section.viewLabelItem "Betalingsmetode"
-                    [ Radio.viewGroup "Betalingsmetode"
-                        [ Radio.init "vipps"
-                            |> Radio.setTitle "Vipps"
-                            |> Radio.setName "paymentType"
-                            |> Radio.setChecked (model.paymentType == Vipps)
-                            |> Radio.setOnCheck (Just <| \_ -> SetPaymentType Vipps)
-                            |> Radio.view
-                        , Radio.init "visa"
-                            |> Radio.setTitle "Bankkort"
-                            |> Radio.setName "paymentType"
-                            |> Radio.setChecked (model.paymentType == Nets)
-                            |> Radio.setOnCheck (Just <| \_ -> SetPaymentType Nets)
-                            |> Radio.view
-                        ]
+                , Radio.viewLabelGroup "Betalingsmetode"
+                    [ Radio.init "vipps"
+                        |> Radio.setTitle "Vipps"
+                        |> Radio.setName "paymentType"
+                        |> Radio.setChecked (model.paymentType == Vipps)
+                        |> Radio.setOnCheck (Just <| \_ -> SetPaymentType Vipps)
+                        |> Radio.view
+                    , Radio.init "visa"
+                        |> Radio.setTitle "Bankkort"
+                        |> Radio.setName "paymentType"
+                        |> Radio.setChecked (model.paymentType == Nets)
+                        |> Radio.setOnCheck (Just <| \_ -> SetPaymentType Nets)
+                        |> Radio.view
                     ]
-                , B.init "Gå til oppsummering"
+                , B.init "Gå til betaling"
                     |> B.setDisabled disableButtons
                     |> B.setIcon (Just <| Icon.viewMonochrome Icon.rightArrow)
                     |> B.setOnClick (Just BuyOffers)

--- a/src/elm/Page/Shop/Utils.elm
+++ b/src/elm/Page/Shop/Utils.elm
@@ -1,0 +1,194 @@
+module Page.Shop.Utils exposing (CommonModel, ModelSummary, TravelDateTime(..), defaultDerivedData, findLimitations, langString, modelSummary, nameFromFareProduct, nameFromUserType, stringFromTravelDate, stringFromZone, stringFromtravelDateTime, userTypeAsIdString)
+
+import Data.RefData exposing (FareProduct, LangString(..), Limitation, TariffZone, UserProfile, UserType(..))
+import Data.Ticket exposing (Offer)
+import List.Extra
+import Shared exposing (Shared)
+import Time
+import Util.Status exposing (Status(..))
+import Util.Time as TimeUtil
+
+
+type TravelDateTime
+    = TravelNow
+    | TravelFuture (Maybe String)
+
+
+type alias CommonModel a =
+    { a
+        | offers : Status (List Offer)
+        , users : List ( UserType, Int )
+        , product : Maybe String
+        , fromZone : Maybe String
+        , toZone : Maybe String
+        , timeZone : Time.Zone
+        , travelDateTime : TravelDateTime
+    }
+
+
+type alias ModelSummary =
+    { users : List ( String, Int )
+    , product : Maybe String
+    , start : Maybe String
+    , zones : Maybe String
+    , duration : Maybe String
+    }
+
+
+defaultDerivedData : Shared -> List FareProduct -> ( String, String )
+defaultDerivedData shared products =
+    let
+        firstZone =
+            shared.tariffZones
+                |> List.sortWith
+                    (\a b ->
+                        case ( a.name, b.name ) of
+                            ( LangString _ nameA, LangString _ nameB ) ->
+                                compare nameA nameB
+                    )
+                |> List.head
+                |> Maybe.map .id
+                |> Maybe.withDefault ""
+
+        defaultProduct =
+            products
+                |> List.head
+                |> Maybe.map .id
+                |> Maybe.withDefault ""
+    in
+        ( firstZone, defaultProduct )
+
+
+modelSummary : ( String, String ) -> Shared -> CommonModel a -> ModelSummary
+modelSummary ( defaultZone, defaultProduct ) shared model =
+    let
+        product =
+            Maybe.withDefault defaultProduct model.product
+    in
+        { users =
+            model.users
+                |> List.map
+                    (Tuple.mapFirst (\a -> a |> nameFromUserType shared.userProfiles |> Maybe.withDefault "-"))
+        , product = nameFromFareProduct shared.fareProducts product
+        , start = stringFromTravelDate model.travelDateTime model.timeZone
+        , zones = stringFromZone shared.tariffZones defaultZone model
+        , duration = nameFromFareProduct shared.fareProducts product
+        }
+
+
+stringFromTravelDate : TravelDateTime -> Time.Zone -> Maybe String
+stringFromTravelDate travelDateTime timeZone =
+    case travelDateTime of
+        TravelNow ->
+            Just "Kjøpstidspunkt"
+
+        TravelFuture (Just time) ->
+            TimeUtil.isoStringToFullHumanized timeZone time
+
+        _ ->
+            Nothing
+
+
+nameFromUserType : List UserProfile -> UserType -> Maybe String
+nameFromUserType profiles userType =
+    profiles
+        |> List.Extra.find (.userType >> (==) userType)
+        |> Maybe.map (.name >> langString)
+
+
+nameFromFareProduct : List FareProduct -> String -> Maybe String
+nameFromFareProduct products productId =
+    products
+        |> List.Extra.find (.id >> (==) productId)
+        |> Maybe.map (.name >> langString)
+
+
+stringFromZone : List TariffZone -> String -> CommonModel a -> Maybe String
+stringFromZone tariffZones defaultZone model =
+    let
+        findName zone =
+            tariffZones
+                |> List.Extra.find (.id >> (==) zone)
+                |> Maybe.map (.name >> langString)
+                |> Maybe.withDefault "-"
+
+        fromZoneName =
+            findName (Maybe.withDefault defaultZone model.fromZone)
+
+        toZoneName =
+            findName (Maybe.withDefault defaultZone model.toZone)
+    in
+        if model.fromZone == model.toZone then
+            Just <| "Reise i 1 sone (" ++ fromZoneName ++ ")"
+
+        else
+            Just <| "Reise fra sone " ++ fromZoneName ++ " til sone " ++ toZoneName
+
+
+langString : LangString -> String
+langString (LangString _ value) =
+    value
+
+
+stringFromtravelDateTime : TravelDateTime -> Maybe String
+stringFromtravelDateTime travelDateTime =
+    case travelDateTime of
+        TravelFuture (Just time) ->
+            Just time
+
+        _ ->
+            Nothing
+
+
+findLimitations : String -> List Limitation -> List UserType
+findLimitations productId fareProducts =
+    fareProducts
+        |> List.Extra.find (.productId >> (==) productId)
+        |> Maybe.map .limitations
+        |> Maybe.withDefault []
+
+
+userTypeAsIdString : UserType -> String
+userTypeAsIdString userType =
+    case userType of
+        UserTypeAdult ->
+            "UserTypeAdult"
+
+        UserTypeChild ->
+            "UserTypeChild"
+
+        UserTypeInfant ->
+            "UserTypeInfant"
+
+        UserTypeSenior ->
+            "UserTypeSenior"
+
+        UserTypeStudent ->
+            "UserTypeStudent"
+
+        UserTypeYoungPerson ->
+            "UserTypeYoungPerson"
+
+        UserTypeSchoolPupil ->
+            "UserTypeSchoolPupil"
+
+        UserTypeMilitary ->
+            "UserTypeMilitary"
+
+        UserTypeDisabled ->
+            "UserTypeDisabled"
+
+        UserTypeDisabledCompanion ->
+            "UserTypeDisabledCompanion"
+
+        UserTypeJobSeeker ->
+            "UserTypeJobSeeker"
+
+        UserTypeEmployee ->
+            "UserTypeEmployee"
+
+        UserTypeAnimal ->
+            "UserTypeAnimal"
+
+        UserTypeAnyone ->
+            "UserTypeAnyone"

--- a/src/elm/Page/ShopCarnet.elm
+++ b/src/elm/Page/ShopCarnet.elm
@@ -9,7 +9,6 @@ import GlobalActions as GA
 import Html as H exposing (Html, summary)
 import Html.Attributes as A
 import Html.Events as E
-import Html.Extra
 import Http
 import List.Extra
 import Notification
@@ -295,7 +294,18 @@ update msg env model shared =
             GoToSummary ->
                 case model.offers of
                     Loaded offers ->
-                        PageUpdater.init { model | summary = Just <| SummaryPage.init offers }
+                        PageUpdater.init
+                            { model
+                                | summary =
+                                    Just <|
+                                        SummaryPage.init
+                                            { productId = Maybe.withDefault "" model.product
+                                            , fromZoneId = Maybe.withDefault "" model.fromZone
+                                            , toZoneId = Maybe.withDefault "" model.toZone
+                                            , travelDate = Nothing
+                                            }
+                                            offers
+                            }
 
                     _ ->
                         PageUpdater.init model
@@ -596,46 +606,6 @@ summaryView shared model disableButtons =
                     |> B.setOnClick (Just GoToSummary)
                     |> B.primary Primary_2
                 ]
-
-
-hasReducedCost : UserType -> Bool
-hasReducedCost userType =
-    case userType of
-        UserTypeAdult ->
-            False
-
-        UserTypeInfant ->
-            False
-
-        UserTypeSchoolPupil ->
-            False
-
-        UserTypeAnimal ->
-            False
-
-        UserTypeAnyone ->
-            False
-
-        _ ->
-            True
-
-
-maybeBuyNotice : List ( UserType, Int ) -> Html msg
-maybeBuyNotice users =
-    let
-        reduced =
-            List.any (Tuple.first >> hasReducedCost) users
-
-        result =
-            if reduced then
-                Just <| Message.info "Husk at du må reise med gyldig moderasjonsbevis"
-
-            else
-                Nothing
-
-        --
-    in
-        Html.Extra.viewMaybe identity result
 
 
 langString : LangString -> String

--- a/src/elm/Ui/Group.elm
+++ b/src/elm/Ui/Group.elm
@@ -40,7 +40,10 @@ view { open, readonly, onOpenClick, icon, id, editTextSuffix, title, value } chi
 
         editText =
             if not open then
-                H.span [ A.class "ui-group__headerButton__editText" ] [ H.text <| "Endre " ++ editTextSuffix, editIcon ]
+                H.span [ A.class "ui-group__headerButton__editText" ]
+                    [ H.span [ A.class "ui-group__headerButton__editText__text" ] [ H.text <| "Endre " ++ editTextSuffix ]
+                    , editIcon
+                    ]
 
             else
                 Icon.upArrow

--- a/src/elm/Ui/Input/Radio.elm
+++ b/src/elm/Ui/Input/Radio.elm
@@ -10,6 +10,7 @@ module Ui.Input.Radio exposing
     , setTitle
     , view
     , viewGroup
+    , viewLabelGroup
     )
 
 import Html as H exposing (Attribute, Html)
@@ -83,8 +84,18 @@ viewGroup : String -> List (Html msg) -> Html msg
 viewGroup hiddenTitle children =
     H.fieldset [ A.class "ui-input-radioGroup" ]
         (H.legend
-            [ A.class "ui-input-radioGroup__hiddenLegend" ]
+            [ A.class "ui-input-radioGroup__legend ui-input-radioGroup__legend--hidden" ]
             [ H.text hiddenTitle ]
+            :: List.map Ui.Group.viewItem children
+        )
+
+
+viewLabelGroup : String -> List (Html msg) -> Html msg
+viewLabelGroup title children =
+    H.fieldset [ A.class "ui-input-radioGroup" ]
+        (H.legend
+            [ A.class "ui-input-radioGroup__legend" ]
+            [ Text.textContainer H.span (Just Text.SecondaryColor) <| Text.Tertiary [ H.text title ] ]
             :: List.map Ui.Group.viewItem children
         )
 

--- a/src/elm/Ui/PageHeader.elm
+++ b/src/elm/Ui/PageHeader.elm
@@ -1,6 +1,7 @@
 module Ui.PageHeader exposing
     ( init
     , setBackButton
+    , setBackIcon
     , setBackRoute
     , setOnCancel
     , setTitle
@@ -20,6 +21,7 @@ type alias PageHeader msg =
     { back : Maybe ( String, Attribute msg, List (Attribute msg) -> List (Html msg) -> Html msg )
     , title : Maybe String
     , onCancel : Maybe ( String, Html msg, msg )
+    , backIcon : Html msg
     }
 
 
@@ -28,6 +30,7 @@ init =
     { back = Nothing
     , title = Nothing
     , onCancel = Nothing
+    , backIcon = Icon.leftArrow
     }
 
 
@@ -50,17 +53,22 @@ setTitle title opts =
     { opts | title = title }
 
 
+setBackIcon : Html msg -> PageHeader msg -> PageHeader msg
+setBackIcon backIcon opts =
+    { opts | backIcon = backIcon }
+
+
 setOnCancel : Maybe ( String, Html msg, msg ) -> PageHeader msg -> PageHeader msg
 setOnCancel onCancel opts =
     { opts | onCancel = onCancel }
 
 
 view : PageHeader msg -> Html msg
-view { back, title, onCancel } =
+view { back, title, onCancel, backIcon } =
     H.div [ A.class "ui-pageHeader" ]
         [ case back of
             Just ( backTitle, action, el ) ->
-                el [ action, A.class "ui-pageHeader__back" ] [ Icon.leftArrow, H.text backTitle ]
+                el [ action, A.class "ui-pageHeader__back" ] [ backIcon, H.text backTitle ]
 
             Nothing ->
                 Html.Extra.nothing

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -296,6 +296,9 @@ p + p {
     margin: 3.25rem auto;
     grid-template-columns: 1fr;
 }
+.page--threeColumns {
+    grid-template-columns: 1fr 1fr 1fr;
+}
 
 .page--overview,
 .page--history {

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -5,6 +5,11 @@
 :root {
     --ws-icon-size-xLarge: 2.5rem;
 }
+@media (max-width: 400px) {
+    :root {
+        --ws-icon-size-xLarge: 1.75rem;
+    }
+}
 
 html {
     box-sizing: border-box;

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -335,6 +335,19 @@ p + p {
     }
 }
 
+// Summary page
+
+.summaryPage__horizontal {
+    display: flex;
+    justify-content: space-between;
+}
+
+.shopPage__separator {
+    margin: var(--spacings-large) 0;
+    border-color: var(--border-secondary);
+    border-top: 0;
+}
+
 // Basic responsiveness for pages
 
 @media (max-width: 768px) {

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -256,6 +256,13 @@
     }
 }
 
+@media (max-width: 500px) {
+    .ui-group__headerButton__editText__text {
+        position: absolute;
+        clip: rect(0 0 0 0);
+    }
+}
+
 .ui-ticketDetails {
     width: 100%;
     border-radius: var(--border-radius-regular);

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -695,7 +695,16 @@
     padding: 0;
     margin: 0;
 }
-.ui-input-radioGroup__hiddenLegend {
+.ui-input-radioGroup__legend {
+    background: var(--colors-background_0-backgroundColor);
+    color: var(--colors-background_0-color);
+    display: block;
+    width: 100%;
+
+    padding: var(--spacings-large);
+    padding-bottom: 0;
+}
+.ui-input-radioGroup__legend--hidden {
     position: absolute;
     clip: rect(0 0 0 0);
 }


### PR DESCRIPTION
Legger til en egen subside for oppsummering. Dette ligger ikke under egen route per nå, men det kan vi vurdere om er hensiktsmessig etterhvert.

Skriver også om til å ha en egen Shop-struktur for pages som gjenbruker logiske funksjoner og views der hensiktsmessig.


Her viser vi ikke "gyldig til". Se egen sak: https://github.com/AtB-AS/atb-ticket/issues/62

TODO:
- [x] Bytte ut `<- Avbryt` til `x Avbryt` i PageHeader


Skjermskudd:

![Screenshot 2021-06-24 at 12 54 56](https://user-images.githubusercontent.com/606374/123251405-74634d00-d4eb-11eb-98f3-ca9163335acf.png)

![Screenshot 2021-06-24 at 12 55 13](https://user-images.githubusercontent.com/606374/123251402-73322000-d4eb-11eb-9aa6-0d89e2320fd3.png)
