### PR TITLE
fix: only show travel card in overview if set

### DIFF
--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -266,18 +266,18 @@ viewAccountInfo shared _ =
                       else
                         Html.Extra.nothing
                     ]
-                , S.viewLabelItem "T:kort"
-                    [ shared.profile
-                        |> Util.Maybe.flatMap .travelCard
-                        |> Maybe.map .id
-                        |> Html.Extra.viewMaybe
-                            (\id ->
-                                H.p [ A.class "accountInfo__item", A.title "t:kort-nummer" ]
+                , shared.profile
+                    |> Util.Maybe.flatMap .travelCard
+                    |> Maybe.map .id
+                    |> Html.Extra.viewMaybe
+                        (\id ->
+                            S.viewLabelItem "T:kort"
+                                [ H.p [ A.class "accountInfo__item", A.title "t:kort-nummer" ]
                                     [ Icon.travelCard
                                     , Ui.TravelCardText.view id
                                     ]
-                            )
-                    ]
+                                ]
+                        )
                 , B.init "Rediger profil"
                     |> B.setDisabled False
                     |> B.setIcon (Just Icon.edit)


### PR DESCRIPTION
Før:
<img width="469" alt="Screenshot 2021-06-26 at 09 59 24" src="https://user-images.githubusercontent.com/606374/123506581-31c58000-d665-11eb-9ba7-4452ea2de971.png">

Etter:
<img width="514" alt="Screenshot 2021-06-26 at 09 59 19" src="https://user-images.githubusercontent.com/606374/123506585-368a3400-d665-11eb-846f-5ea9f1d6ee92.png">

