### PR TITLE
fix: only show validity warning when logged in

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -509,6 +509,9 @@ update msg model =
                             Just Route.Settings ->
                                 TaskUtil.doTask <| AccountMsg AccountPage.OnEnterPage
 
+                            Just (Route.Login path) ->
+                                TaskUtil.doTask <| LoginMsg <| LoginPage.OnEnterPage path
+
                             _ ->
                                 Cmd.none
                         )

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -567,16 +567,25 @@ view model =
 
 wrapPage : Model -> List (Html Msg) -> Html Msg
 wrapPage model children =
-    H.div [ A.class "light container" ]
-        [ viewAuthError model
-        , header model
-        , Html.Extra.viewIf model.environment.showValidityWarning <| viewValidityWarning model
-        , H.main_ [ A.class "app" ]
-            [ Ui.GlobalNotifications.notifications model.notifications
-            , H.div [ A.class "content" ]
-                children
+    let
+        showVisibility =
+            case ( model.userData, model.verifyUser, model.onboarding ) of
+                ( _, Just _, Just _ ) ->
+                    False
+
+                _ ->
+                    model.environment.showValidityWarning && model.environment.customerId /= Nothing
+    in
+        H.div [ A.class "light container" ]
+            [ viewAuthError model
+            , header model
+            , Html.Extra.viewIf showVisibility (viewValidityWarning model)
+            , H.main_ [ A.class "app" ]
+                [ Ui.GlobalNotifications.notifications model.notifications
+                , H.div [ A.class "content" ]
+                    children
+                ]
             ]
-        ]
 
 
 viewValidityWarning : Model -> Html Msg


### PR DESCRIPTION
Hindrer at melding om billett-validitet vises om du ikke er logget inn.