### PR TITLE
chore: adds release drafter gh action

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+
+on:
+    push:
+        branches:
+            - master
+    pull_request:
+        types: [opened, reopened, synchronize]
+
+jobs:
+    update_release_draft:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: release-drafter/release-drafter@v5
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -12,5 +12,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: release-drafter/release-drafter@v5
+              with:
+                  config-name: release-drafter.yml
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Forslag om å legge til Release Drafter som GH Action. Den vil opprette en draft release og oppdatere den kontinuerlig med endringer. Slik synliggjør vi kommende endringer og det gjør arbeidet enklere for å release nye oppdateringer.

Usikker på om dette gjøres på Pull Request nivå (som jeg håper) eller om den ser på commits. Om det er på commits må vi alltid squashe og se på semantiske titler på merge. Om det er på pull requests er det enklere for da trenger vi bare opprette korrekt pullrequest tittel som vi ønsker skal dukke opp i changelog.