### PR TITLE
fix: reload page on expired jwt

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -32,6 +32,14 @@ XMLHttpRequest.prototype.open = function (...args) {
         )
     ) {
         this.setRequestHeader('Atb-Request-Id', uuidv4());
+        this.addEventListener('loadend', function (e) {
+            // When on custom services (e.g. ticketing service),
+            // if we get 401 due to some stale state and token not
+            // being refreshed, reload screen.
+            if (e.currentTarget.status === 401) {
+                document.location.reload();
+            }
+        });
     }
     return res;
 };


### PR DESCRIPTION
Legger til flere forsøk på å hente ut gyldig token om det er noe feil med expiretime som blir returnert. Dette skal forhåpentligvis fikse utgått JWTs. 

Om refresh token er ugyldig så fanges det ikke opp. Dette kan skje med at bruker blir disabled/slettet eller endrer innloggingsinformasjon. Må verifisere hvordan det håndteres.