### PR TITLE
feat: Små forbedringer til tydelighet for telefonnummer

### DIFF
--- a/src/elm/Page/Account.elm
+++ b/src/elm/Page/Account.elm
@@ -62,6 +62,7 @@ type Msg
     | UpdateLastName String
     | UpdateEmail String
     | UpdatePhone String
+    | OnInputPhoneFocus
     | InputTravelCard String
     | StateTravelCard MaskedInput.State
     | ReceiveUpdateProfile (List FieldName) (Result Http.Error ())
@@ -162,6 +163,17 @@ update msg env model =
         UpdatePhone value ->
             PageUpdater.init { model | phone = value }
 
+        OnInputPhoneFocus ->
+            PageUpdater.init
+                { model
+                    | phone =
+                        if String.isEmpty model.phone then
+                            "+47"
+
+                        else
+                            model.phone
+                }
+
         ResetPassword email ->
             PageUpdater.init model
                 |> ("E-post med for å sette nytt passord er sendt til "
@@ -206,7 +218,7 @@ update msg env model =
             let
                 modelWithCode =
                     { model
-                        | phone = Util.PhoneNumber.withCountryCode model.phone
+                        | phone = Util.PhoneNumber.withDefaultCountryCode model.phone
                     }
             in
                 case validatePhone .phone modelWithCode of
@@ -639,12 +651,12 @@ viewPhoneNumber model profile =
                             EditSection.horizontalGroup
                                 [ Text.init "phone"
                                     |> Text.setTitle (Just "Telefonnummer")
-                                    |> Text.setError (Validation.select PhoneInput model.validationErrors)
                                     |> Text.setOnInput (Just <| UpdatePhone)
                                     |> Text.setPlaceholder "Legg til et telefonnummer"
                                     |> Text.setValue (Just model.phone)
                                     |> Text.setType "tel"
                                     |> Text.setError (Validation.select PhoneInput model.validationErrors)
+                                    |> Text.setAttributes [ E.onFocus OnInputPhoneFocus ]
                                     |> Text.view
                                 ]
 

--- a/src/elm/Page/Account.elm
+++ b/src/elm/Page/Account.elm
@@ -430,8 +430,12 @@ validateEmail sel model =
 
 
 validatePhone : (Model -> String) -> Model -> Result (List (FormError FieldName)) (Valid Model)
-validatePhone sel =
-    Validation.validate (Validation.phoneValidator PhoneInput sel)
+validatePhone sel model =
+    if String.isEmpty <| sel model then
+        Validation.validate Validation.void model
+
+    else
+        Validation.validate (Validation.phoneValidator PhoneInput sel) model
 
 
 validateTravelCard : Model -> Result (List (FormError FieldName)) (Valid Model)
@@ -655,6 +659,7 @@ viewPhoneNumber model profile =
                                     |> Text.setPlaceholder "Legg til et telefonnummer"
                                     |> Text.setValue (Just model.phone)
                                     |> Text.setType "tel"
+                                    |> Text.setRequired False
                                     |> Text.setError (Validation.select PhoneInput model.validationErrors)
                                     |> Text.setAttributes [ E.onFocus OnInputPhoneFocus ]
                                     |> Text.view

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -44,6 +44,7 @@ type Msg
     | OnLeavePage LoginMethodPath
     | HideInfoStep
     | InputPhone String
+    | OnPhoneInputFocus
     | InputCode String
     | InputEmail String
     | InputPassword String
@@ -121,6 +122,17 @@ update msg env model navKey =
 
         InputPhone value ->
             PageUpdater.init { model | phone = value, validationErrors = V.remove PhoneField model.validationErrors }
+
+        OnPhoneInputFocus ->
+            PageUpdater.init
+                { model
+                    | phone =
+                        if String.isEmpty model.phone then
+                            "+47"
+
+                        else
+                            model.phone
+                }
 
         InputCode value ->
             PageUpdater.init { model | code = value }
@@ -493,6 +505,7 @@ viewPhoneInputs model =
         |> T.setError (V.select PhoneField model.validationErrors)
         |> T.setTitle (Just "Telefonnummer")
         |> T.setPlaceholder "Logg inn med telefonnummeret ditt"
+        |> T.setAttributes [ E.onFocus OnPhoneInputFocus ]
         |> T.view
     ]
 

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -226,7 +226,7 @@ validateLogin : Model -> Result (List (FormError FieldName)) (Valid Model)
 validateLogin model =
     case model.loginMethod of
         PhoneMethod ->
-            validatePhone { model | phone = Util.PhoneNumber.withCountryCode model.phone }
+            validatePhone { model | phone = Util.PhoneNumber.withDefaultCountryCode model.phone }
 
         ResetEmailMethod ->
             validateEmail model
@@ -268,7 +268,7 @@ methodPathToPath path =
 
 loginUsingPhone : String -> Cmd Msg
 loginUsingPhone phoneNumber =
-    FirebaseAuth.loginPhone <| Util.PhoneNumber.withCountryCode phoneNumber
+    FirebaseAuth.loginPhone <| Util.PhoneNumber.withDefaultCountryCode phoneNumber
 
 
 loginUsingEmail : String -> String -> Cmd Msg

--- a/src/elm/Page/Onboarding.elm
+++ b/src/elm/Page/Onboarding.elm
@@ -7,6 +7,7 @@ import Environment exposing (Environment)
 import Fragment.Icon as Icon
 import Html as H exposing (Html)
 import Html.Attributes as A
+import Html.Events as E
 import Html.Extra
 import Http exposing (Error(..))
 import Json.Decode as Decode
@@ -36,6 +37,7 @@ type Msg
     | InputFirstName String
     | InputLastName String
     | InputPhone String
+    | OnInputPhoneFocus
     | ToggleConsent Int Bool
     | Register
     | ReceiveRegisterProfile (Result Http.Error ())
@@ -140,10 +142,21 @@ update msg env shared model =
         InputPhone value ->
             PageUpdater.init { model | phone = value, validationErrors = (V.remove PhoneField >> V.remove RegisterForm) model.validationErrors }
 
+        OnInputPhoneFocus ->
+            PageUpdater.init
+                { model
+                    | phone =
+                        if String.isEmpty model.phone then
+                            "+47"
+
+                        else
+                            model.phone
+                }
+
         Register ->
             let
                 modelWithCountryCode =
-                    { model | phone = Util.PhoneNumber.withCountryCode model.phone }
+                    { model | phone = Util.PhoneNumber.withDefaultCountryCode model.phone }
             in
                 case validatePersonalInfo modelWithCountryCode of
                     Ok _ ->
@@ -474,7 +487,7 @@ viewProfileInfo _ model =
                 |> TextInput.setOnInput (Just InputPhone)
                 |> TextInput.setValue (Just model.phone)
                 |> TextInput.setError (V.select PhoneField model.validationErrors)
-                |> TextInput.setAttributes [ A.readonly model.isReadonlyPhone ]
+                |> TextInput.setAttributes [ A.readonly model.isReadonlyPhone, E.onFocus OnInputPhoneFocus ]
                 |> TextInput.view
             ]
         , Section.viewItem

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -24,6 +24,7 @@ import Ui.LabelItem as LabelItem
 import Ui.Message
 import Ui.Section as Section
 import Util.Format
+import Util.PhoneNumber
 import Util.Status exposing (Status(..))
 
 
@@ -137,7 +138,7 @@ view shared model =
             , H.div [ A.class "page page--threeColumns" ]
                 [ viewTicketSection summary
                 , viewPriceSection summary
-                , viewPaymentSection model
+                , viewPaymentSection model shared
                 ]
             ]
 
@@ -257,8 +258,8 @@ viewPriceSection summary =
             ]
 
 
-viewPaymentSection : Model -> Html Msg
-viewPaymentSection model =
+viewPaymentSection : Model -> Shared -> Html Msg
+viewPaymentSection model shared =
     let
         disableButtons =
             case model.reservation of
@@ -285,12 +286,34 @@ viewPaymentSection model =
                     |> Radio.view
                 ]
             , maybeBuyNotice model.offers
+            , maybeVippsNotice model shared
             , B.init "Gå til betaling"
                 |> B.setDisabled disableButtons
                 |> B.setIcon (Just <| Icon.viewMonochrome Icon.rightArrow)
                 |> B.setOnClick (Just BuyOffers)
                 |> B.primary Primary_2
             ]
+
+
+maybeVippsNotice : Model -> Shared -> Html Msg
+maybeVippsNotice model shared =
+    let
+        isVipps =
+            model.paymentType == Vipps
+
+        maybeIsNotDefaultCountryCode =
+            shared.profile
+                |> Maybe.map .phone
+                |> Maybe.map Util.PhoneNumber.isDefaultCountryCode
+                |> Maybe.map not
+                |> Maybe.map ((&&) isVipps)
+    in
+        case maybeIsNotDefaultCountryCode of
+            Just True ->
+                Ui.Message.warning "Vipps støtter ikke betaling fra telefonnummer med landskode annet enn +47."
+
+            _ ->
+                Html.Extra.nothing
 
 
 viewTravellerData : TravellerData -> Html Msg

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -301,19 +301,19 @@ maybeVippsNotice model shared =
         isVipps =
             model.paymentType == Vipps
 
-        maybeIsNotDefaultCountryCode =
+        phone =
             shared.profile
                 |> Maybe.map .phone
-                |> Maybe.map Util.PhoneNumber.isDefaultCountryCode
-                |> Maybe.map not
-                |> Maybe.map ((&&) isVipps)
-    in
-        case maybeIsNotDefaultCountryCode of
-            Just True ->
-                Ui.Message.warning "Vipps støtter ikke betaling fra telefonnummer med landskode annet enn +47."
+                |> Maybe.withDefault ""
 
-            _ ->
-                Html.Extra.nothing
+        hasDefaultCountryCode =
+            String.isEmpty phone || Util.PhoneNumber.isDefaultCountryCode phone
+    in
+        if hasDefaultCountryCode || not isVipps then
+            Html.Extra.nothing
+
+        else
+            Ui.Message.warning "Vipps støtter ikke betaling fra telefonnummer med landskode annet enn +47."
 
 
 viewTravellerData : TravellerData -> Html Msg

--- a/src/elm/Util/PhoneNumber.elm
+++ b/src/elm/Util/PhoneNumber.elm
@@ -1,4 +1,4 @@
-module Util.PhoneNumber exposing (format, withDefaultCountryCode, withoutCountryCode)
+module Util.PhoneNumber exposing (format, isDefaultCountryCode, withDefaultCountryCode, withoutCountryCode)
 
 import Util.NumberFormater as NF
 
@@ -26,6 +26,11 @@ withDefaultCountryCode phone =
         "+47" ++ phone
 
 
+isDefaultCountryCode : String -> Bool
+isDefaultCountryCode =
+    String.startsWith "+47"
+
+
 format : String -> String
 format phone =
     let
@@ -35,18 +40,22 @@ format phone =
         actualPhone =
             withoutCountryCode phone
     in
-        -- @TODO This will be incorrect on country codes other than 2 digits.
-        -- Currently visual noice, but not critica. At some point extend to use
-        -- proper parsing of country codes.
-        NF.formatString
-            [ NF.Str countryCode
-            , NF.Space
-            , NF.Digits 2
-            , NF.Space
-            , NF.Digits 2
-            , NF.Space
-            , NF.Digits 2
-            , NF.Space
-            , NF.Digits 2
-            ]
-            actualPhone
+        if not (isDefaultCountryCode phone) then
+            phone
+
+        else
+            -- @TODO This will be incorrect on country codes other than 2 digits.
+            -- Currently visual noice, but not critica. At some point extend to use
+            -- proper parsing of country codes.
+            NF.formatString
+                [ NF.Str countryCode
+                , NF.Space
+                , NF.Digits 2
+                , NF.Space
+                , NF.Digits 2
+                , NF.Space
+                , NF.Digits 2
+                , NF.Space
+                , NF.Digits 2
+                ]
+                actualPhone

--- a/src/elm/Util/PhoneNumber.elm
+++ b/src/elm/Util/PhoneNumber.elm
@@ -1,4 +1,4 @@
-module Util.PhoneNumber exposing (format, withCountryCode, withoutCountryCode)
+module Util.PhoneNumber exposing (format, withDefaultCountryCode, withoutCountryCode)
 
 import Util.NumberFormater as NF
 
@@ -14,8 +14,8 @@ withoutCountryCode phone =
         phone
 
 
-withCountryCode : String -> String
-withCountryCode phone =
+withDefaultCountryCode : String -> String
+withDefaultCountryCode phone =
     if String.isEmpty phone then
         phone
 
@@ -35,6 +35,9 @@ format phone =
         actualPhone =
             withoutCountryCode phone
     in
+        -- @TODO This will be incorrect on country codes other than 2 digits.
+        -- Currently visual noice, but not critica. At some point extend to use
+        -- proper parsing of country codes.
         NF.formatString
             [ NF.Str countryCode
             , NF.Space

--- a/src/elm/Util/Validation.elm
+++ b/src/elm/Util/Validation.elm
@@ -64,9 +64,8 @@ travelCardValidator field toValue =
 phoneValidator : a -> (subject -> String) -> Validate.Validator (FormError a) subject
 phoneValidator field toValue =
     Validate.firstError
-        [ ifNotLength 11 toValue ( field, "Telefonnummeret må bestå av 8 siffer" )
-        , Validate.ifFalse (\model -> String.startsWith "+" (toValue model)) ( field, "Telefonnummeret må ha med landskode" )
-        , Validate.ifNotInt (toValue >> String.replace "+" "") (\_ -> ( field, "Telefonnummer må være et tall på 8 siffer." ))
+        [ Validate.ifFalse (\model -> String.startsWith "+" (toValue model)) ( field, "Telefonnummeret må inkludere landskode" )
+        , Validate.ifNotInt (toValue >> String.replace "+" "") (\_ -> ( field, "Telefonnummeret kan kun bestå av siffer (med eventuell landskode)." ))
         ]
 
 


### PR DESCRIPTION
Det var tidligere litt usikkerhet rundt utenlandske telefonnummer og bruk av de i nettbutikken. Entur støtter det med Vipps støtter det ikke. Dette er også slik det fungerer i dag men det er noe implisitt med standard landskode.

Dette prøver å gjøre det mer tydelig med å:

- Forhåndsutfylle landskode visuelt (+47).
- Legger på landskode om mangler (default +47)
- Viser advarsel rundt vipps i kjøpsflyt dersom du har ikke-NO telefonnummer.

Den fikser også at telefonnummer er valgfritt så man kan fjerne det i profil i ettertid.

Closes #254

![Screenshot 2021-07-06 at 14 14 35](https://user-images.githubusercontent.com/606374/124599689-3ad4ff00-de66-11eb-94e5-6e4924b18943.png)



