### PR TITLE
feat: Add Html.Keyed to headings

### DIFF
--- a/src/elm/Ui/PageHeader.elm
+++ b/src/elm/Ui/PageHeader.elm
@@ -12,6 +12,7 @@ import Html as H exposing (Attribute, Html)
 import Html.Attributes as A
 import Html.Events as E
 import Html.Extra
+import Html.Keyed as Keyed
 import Route exposing (Route)
 import Ui.Button as B
 import Ui.TextContainer
@@ -55,7 +56,7 @@ setBackIcon backIcon opts =
 view : PageHeader msg -> Html msg
 view { back, title, backIcon } =
     H.div [ A.class "ui-pageHeader" ]
-        [ Html.Extra.viewMaybe (\text -> H.h2 [ A.class "ui-pageHeader__title" ] [ Ui.TextContainer.primaryJumboInline [ H.text text ] ]) title
+        [ Html.Extra.viewMaybe (\text -> Keyed.node "h2" [ A.class "ui-pageHeader__title" ] [ ( text, Ui.TextContainer.primaryJumboInline [ H.text text ] ) ]) title
         , viewMaybeButton back backIcon
         ]
 

--- a/src/elm/Ui/ProgressHeader.elm
+++ b/src/elm/Ui/ProgressHeader.elm
@@ -13,6 +13,7 @@ import Fragment.Icon as Icon
 import Html as H exposing (Html)
 import Html.Attributes as A
 import Html.Extra
+import Html.Keyed as Keyed
 import Ui.Button as B
 import Ui.Heading exposing (title)
 import Ui.TextContainer
@@ -65,7 +66,7 @@ setTotalSteps totalSteps opts =
 view : ProgressHeader msg -> Html msg
 view { title, back, next, step, totalSteps } =
     H.div [ A.class "ui-progressHeader" ]
-        [ H.h2 [ A.class "ui-progressHeader__title" ] [ Ui.TextContainer.primaryJumboInline [ H.text title ] ]
+        [ Keyed.node "h2" [ A.class "ui-progressHeader__title" ] [ ( title, Ui.TextContainer.primaryJumboInline [ H.text title ] ) ]
         , H.div [ A.class "ui-progressHeader__progressContainer" ]
             [ viewMaybeButton Left back
             , viewProgress title step totalSteps


### PR DESCRIPTION
Some heading text changes is not registered by screen readers as the
virtual dom does not change, only the text content. By using Html.Keyed
and using the text as the keyed value, the node will be replaced in the
dom, and the change registered by the screen reader.