### PR TITLE
feat: Focus headings after changing page

### DIFF
--- a/src/elm/Page/Account.elm
+++ b/src/elm/Page/Account.elm
@@ -126,9 +126,9 @@ update : Msg -> Environment -> Model -> PageUpdater Model Msg
 update msg env model =
     case msg of
         OnEnterPage ->
-            PageUpdater.init model
+            PageUpdater.fromPair ( model, TaskUtil.doTask FetchConsents )
                 |> (PageUpdater.addGlobalAction <| GA.SetTitle <| Just "Min profil")
-                |> (PageUpdater.addCmd <| TaskUtil.doTask FetchConsents)
+                |> (PageUpdater.addGlobalAction <| GA.FocusItem <| Just "page-header")
 
         ResetState ->
             let

--- a/src/elm/Page/History.elm
+++ b/src/elm/Page/History.elm
@@ -67,10 +67,8 @@ update msg env model =
     case msg of
         OnEnterPage ->
             PageUpdater.init model
-                |> (Just "Kjøpshistorikk"
-                        |> GA.SetTitle
-                        |> PageUpdater.addGlobalAction
-                   )
+                |> (PageUpdater.addGlobalAction <| GA.SetTitle <| Just "Kjøpshistorikk")
+                |> (PageUpdater.addGlobalAction <| GA.FocusItem <| Just "page-header")
 
         InputFrom value ->
             PageUpdater.init { model | from = Just value }

--- a/src/elm/Page/Onboarding.elm
+++ b/src/elm/Page/Onboarding.elm
@@ -299,7 +299,7 @@ update msg env shared model =
                     Just TravelCard ->
                         if model.profileSaved then
                             PageUpdater.init { model | step = TravelCard, validationErrors = V.init }
-                                |> PageUpdater.addGlobalAction (GA.FocusItem <| Just "travelCard")
+                                |> (PageUpdater.addGlobalAction <| GA.FocusItem <| Just "travelCard")
 
                         else
                             PageUpdater.init model
@@ -313,6 +313,7 @@ update msg env shared model =
                                     , consentEmail = model.savedEmail
                                     , validationErrors = V.init
                                 }
+                                |> (PageUpdater.addGlobalAction <| GA.FocusItem <| Just "progress-header")
 
                         else
                             PageUpdater.init model
@@ -323,6 +324,7 @@ update msg env shared model =
 
                     Just next ->
                         PageUpdater.init { model | step = next, validationErrors = V.init }
+                            |> (PageUpdater.addGlobalAction <| GA.FocusItem <| Just "progress-header")
 
         PrevStep ->
             let
@@ -335,6 +337,7 @@ update msg env shared model =
 
                     Just prev ->
                         PageUpdater.init { model | step = prev, validationErrors = V.init }
+                            |> (PageUpdater.addGlobalAction <| GA.FocusItem <| Just "progress-header")
 
 
 getError : Http.Error -> Maybe String

--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -87,10 +87,8 @@ update msg env model shared =
     case msg of
         OnEnterPage ->
             PageUpdater.init model
-                |> (Nothing
-                        |> GA.SetTitle
-                        |> PageUpdater.addGlobalAction
-                   )
+                |> (PageUpdater.addGlobalAction <| GA.SetTitle <| Nothing)
+                |> (PageUpdater.addGlobalAction <| GA.FocusItem <| Just "page-header")
 
         ReceiveFareContracts result ->
             case result of

--- a/src/elm/Page/Shop/Carnet.elm
+++ b/src/elm/Page/Shop/Carnet.elm
@@ -89,10 +89,8 @@ update msg env model shared =
 
         OnEnterPage ->
             PageUpdater.fromPair ( model, Tuple.second init )
-                |> (Just "Kjøp billett"
-                        |> GA.SetTitle
-                        |> PageUpdater.addGlobalAction
-                   )
+                |> (PageUpdater.addGlobalAction <| GA.SetTitle <| Just "Kjøp billett")
+                |> (PageUpdater.addGlobalAction <| GA.FocusItem <| Just "page-header")
 
         OnLeavePage ->
             PageUpdater.init { model | summary = Nothing }

--- a/src/elm/Page/Shop/Period.elm
+++ b/src/elm/Page/Shop/Period.elm
@@ -124,10 +124,8 @@ update msg env model shared =
 
         OnEnterPage ->
             PageUpdater.fromPair ( model, Tuple.second init )
-                |> (Just "Kjøp billett"
-                        |> GA.SetTitle
-                        |> PageUpdater.addGlobalAction
-                   )
+                |> (PageUpdater.addGlobalAction <| GA.SetTitle <| Just "Kjøp billett")
+                |> (PageUpdater.addGlobalAction <| GA.FocusItem <| Just "page-header")
 
         OnLeavePage ->
             PageUpdater.init { model | summary = Nothing }

--- a/src/elm/Ui/Button.elm
+++ b/src/elm/Ui/Button.elm
@@ -175,21 +175,12 @@ button mode color { text, disabled, isLoading, icon, iconPosition, transparent, 
 
             else
                 Html.Extra.viewMaybe (List.singleton >> H.span [ A.classList iconClassList ]) icon
-
-        ariaLive =
-            case ( isLoading, disabled ) of
-                ( False, False ) ->
-                    "off"
-
-                ( _, _ ) ->
-                    "assertive"
     in
         element
             ([ A.classList classList
              , Html.Attributes.Extra.attributeMaybe E.onClick maybeOnClick
              , A.attribute "aria-disabled" (boolToString disabledOrLoading)
              , A.type_ type_
-             , A.attribute "aria-live" ariaLive
              , Html.Attributes.Extra.attributeIf isLoading <| A.attribute "aria-busy" "true"
              , Html.Attributes.Extra.attributeIf isLoading <| A.attribute "aria-label" (text ++ " (Laster)")
              ]

--- a/src/elm/Ui/Message.elm
+++ b/src/elm/Ui/Message.elm
@@ -66,6 +66,19 @@ statusToIcon status =
             Icon.info
 
 
+statusToRole : UserStatus msg -> String
+statusToRole status =
+    case status of
+        Warning _ ->
+            "alert"
+
+        Error _ ->
+            "alert"
+
+        _ ->
+            ""
+
+
 stringOfStatus : UserStatus msg -> Html msg
 stringOfStatus status =
     case status of
@@ -113,7 +126,11 @@ messageWithOptions options statusType =
     in
         H.div [ A.classList classList ]
             [ icon
-            , H.div [ A.class "ui-message__content", A.attribute "role" "alert" ] [ text ]
+            , H.div
+                [ A.class "ui-message__content"
+                , A.attribute "role" (statusToRole statusType)
+                ]
+                [ text ]
             ]
 
 

--- a/src/elm/Ui/PageHeader.elm
+++ b/src/elm/Ui/PageHeader.elm
@@ -56,8 +56,17 @@ setBackIcon backIcon opts =
 view : PageHeader msg -> Html msg
 view { back, title, backIcon } =
     H.div [ A.class "ui-pageHeader" ]
-        [ Html.Extra.viewMaybe (\text -> Keyed.node "h2" [ A.class "ui-pageHeader__title" ] [ ( text, Ui.TextContainer.primaryJumboInline [ H.text text ] ) ]) title
-        , viewMaybeButton back backIcon
+        [ viewMaybeButton back backIcon
+        , Html.Extra.viewMaybe
+            (\text ->
+                Keyed.node "h2"
+                    [ A.id "page-header"
+                    , A.class "ui-pageHeader__title"
+                    , A.tabindex -1
+                    ]
+                    [ ( text, Ui.TextContainer.primaryJumboInline [ H.text text ] ) ]
+            )
+            title
         ]
 
 

--- a/src/elm/Ui/ProgressHeader.elm
+++ b/src/elm/Ui/ProgressHeader.elm
@@ -8,14 +8,12 @@ module Ui.ProgressHeader exposing
     , view
     )
 
-import Browser.Navigation exposing (back)
 import Fragment.Icon as Icon
 import Html as H exposing (Html)
 import Html.Attributes as A
 import Html.Extra
 import Html.Keyed as Keyed
 import Ui.Button as B
-import Ui.Heading exposing (title)
 import Ui.TextContainer
 
 
@@ -66,7 +64,9 @@ setTotalSteps totalSteps opts =
 view : ProgressHeader msg -> Html msg
 view { title, back, next, step, totalSteps } =
     H.div [ A.class "ui-progressHeader" ]
-        [ Keyed.node "h2" [ A.class "ui-progressHeader__title" ] [ ( title, Ui.TextContainer.primaryJumboInline [ H.text title ] ) ]
+        [ Keyed.node "h2"
+            [ A.id "progress-header", A.tabindex -1, A.class "ui-progressHeader__title" ]
+            [ ( title, Ui.TextContainer.primaryJumboInline [ H.text title ] ) ]
         , H.div [ A.class "ui-progressHeader__progressContainer" ]
             [ viewMaybeButton Left back
             , viewProgress title step totalSteps

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -563,6 +563,9 @@
     padding: var(--spacings-medium);
     order: 2;
 }
+.ui-pageHeader__title:focus {
+    outline: none;
+}
 .ui-pageHeader__back {
     order: 1;
 
@@ -1162,6 +1165,10 @@ a.ui-button--link,
     order: 2;
     text-align: center;
     margin: var(--spacings-medium);
+}
+
+.ui-progressHeader__title:focus {
+    outline: none;
 }
 
 @media (max-width: 400px) {


### PR DESCRIPTION
When a user using a screen reader navigates the webshop, the heading
should be focused when changing page. This is more inline with the
guidelines for WGAT 2.0 2.4.3.

This was made possible by using the domFocus helper from Elm. The
focusable elements needs to have an id, and a tab-index too be
focusable. The tab-index is set to -1 to not be accessible during normal
tabbing.

Changed message-box aria-live to only be assertive when the status level
is Error or Warning. Also removed aria-live from buttons, which are no
longer assertive if disabled or loading.