### PR TITLE
Add support for more payment types

### DIFF
--- a/src/elm/Data/PaymentType.elm
+++ b/src/elm/Data/PaymentType.elm
@@ -1,0 +1,69 @@
+module Data.PaymentType exposing
+    ( PaymentCard(..)
+    , PaymentType(..)
+    , fromString
+    , toInt
+    , toString
+    )
+
+
+type PaymentCard
+    = Visa
+    | MasterCard
+    | AmericanExpress
+
+
+type PaymentType
+    = Nets PaymentCard
+    | Vipps
+
+
+fromString : String -> Maybe PaymentType
+fromString paymentType =
+    case paymentType of
+        "visa" ->
+            Just <| Nets Visa
+
+        "mastercard" ->
+            Just <| Nets MasterCard
+
+        "amex" ->
+            Just <| Nets AmericanExpress
+
+        "vipps" ->
+            Just Vipps
+
+        _ ->
+            Nothing
+
+
+toString : PaymentType -> String
+toString paymentType =
+    case paymentType of
+        Nets Visa ->
+            "visa"
+
+        Nets MasterCard ->
+            "mastercard"
+
+        Nets AmericanExpress ->
+            "amex"
+
+        Vipps ->
+            "vipps"
+
+
+toInt : PaymentType -> Int
+toInt paymentType =
+    case paymentType of
+        Nets Visa ->
+            3
+
+        Nets MasterCard ->
+            4
+
+        Nets AmericanExpress ->
+            5
+
+        Vipps ->
+            2

--- a/src/elm/Data/Ticket.elm
+++ b/src/elm/Data/Ticket.elm
@@ -1,7 +1,6 @@
 module Data.Ticket exposing
     ( Offer
     , PaymentStatus
-    , PaymentType(..)
     , Price
     , Reservation
     , ReservationStatus(..)
@@ -57,8 +56,3 @@ type alias PaymentStatus =
     , status : String
     , paymentType : String
     }
-
-
-type PaymentType
-    = Nets
-    | Vipps

--- a/src/elm/Page/Shop/Carnet.elm
+++ b/src/elm/Page/Shop/Carnet.elm
@@ -2,7 +2,7 @@ module Page.Shop.Carnet exposing (Model, Msg(..), init, subscriptions, update, v
 
 import Base exposing (AppInfo)
 import Data.RefData exposing (LangString(..), ProductType(..), UserType(..))
-import Data.Ticket exposing (Offer, PaymentType(..), Reservation)
+import Data.Ticket exposing (Offer, Reservation)
 import Environment exposing (Environment)
 import Fragment.Icon as Icon
 import GlobalActions as GA

--- a/src/elm/Page/Shop/Period.elm
+++ b/src/elm/Page/Shop/Period.elm
@@ -3,7 +3,7 @@ module Page.Shop.Period exposing (Model, Msg(..), init, subscriptions, update, v
 import Base exposing (AppInfo)
 import Data.FareContract exposing (FareContract, FareContractState(..))
 import Data.RefData exposing (FareProduct, LangString(..), ProductType(..), UserType(..))
-import Data.Ticket exposing (Offer, PaymentType(..), Reservation)
+import Data.Ticket exposing (Offer, Reservation)
 import Environment exposing (Environment)
 import Fragment.Icon as Icon
 import GlobalActions as GA

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -1,7 +1,8 @@
 module Page.Shop.Summary exposing (Model, Msg, Summary, TravellerData, init, makeSummary, subscriptions, update, view)
 
+import Data.PaymentType as PaymentType exposing (PaymentCard(..), PaymentType(..))
 import Data.RefData exposing (FareProduct, LangString(..), ProductType(..), UserProfile, UserType(..))
-import Data.Ticket exposing (Offer, PaymentType(..), Reservation)
+import Data.Ticket exposing (Offer, Reservation)
 import Environment exposing (Environment)
 import Fragment.Icon as Icon
 import GlobalActions as GA
@@ -272,23 +273,23 @@ viewPaymentSection model shared =
 
                 _ ->
                     False
+
+        paymentTypes =
+            [ ( "Vipps", Vipps )
+            , ( "MasterCard", Nets MasterCard )
+            , ( "Visa", Nets Visa )
+            , ( "American Express", Nets AmericanExpress )
+            ]
     in
         Section.view
             [ Section.viewHeader "Betaling"
-            , Radio.viewLabelGroup "Betalingsmetode"
-                [ Radio.init "vipps"
-                    |> Radio.setTitle "Vipps"
-                    |> Radio.setName "paymentType"
-                    |> Radio.setChecked (model.paymentType == Vipps)
-                    |> Radio.setOnCheck (Just <| \_ -> SetPaymentType Vipps)
-                    |> Radio.view
-                , Radio.init "visa"
-                    |> Radio.setTitle "Bankkort"
-                    |> Radio.setName "paymentType"
-                    |> Radio.setChecked (model.paymentType == Nets)
-                    |> Radio.setOnCheck (Just <| \_ -> SetPaymentType Nets)
-                    |> Radio.view
-                ]
+            , paymentTypes
+                |> List.filter
+                    (\( _, paymentType ) ->
+                        List.member paymentType shared.paymentTypes
+                    )
+                |> List.map (paymentTypeRadio model)
+                |> Radio.viewLabelGroup "Betalingsmetode"
             , maybeBuyNotice model.offers
             , maybeVippsNotice model shared
             , B.init "Gå til betaling"
@@ -297,6 +298,16 @@ viewPaymentSection model shared =
                 |> B.setOnClick (Just BuyOffers)
                 |> B.primary Primary_2
             ]
+
+
+paymentTypeRadio : Model -> ( String, PaymentType ) -> Html Msg
+paymentTypeRadio model ( title, paymentType ) =
+    Radio.init (PaymentType.toString paymentType)
+        |> Radio.setTitle title
+        |> Radio.setName "paymentType"
+        |> Radio.setChecked (model.paymentType == paymentType)
+        |> Radio.setOnCheck (Just <| \_ -> SetPaymentType paymentType)
+        |> Radio.view
 
 
 maybeVippsNotice : Model -> Shared -> Html Msg

--- a/src/elm/Service/RefData.elm
+++ b/src/elm/Service/RefData.elm
@@ -4,10 +4,12 @@ port module Service.RefData exposing
     , getUserProfiles
     , onConsents
     , onFareProducts
+    , onPaymentTypes
     , onTariffZones
     , onUserProfiles
     )
 
+import Data.PaymentType as PaymentType exposing (PaymentType)
 import Data.RefData exposing (Consent, DistributionChannel(..), FareProduct, LangString(..), ProductType(..), TariffZone, UserProfile, UserType(..))
 import Environment exposing (Environment)
 import Http
@@ -185,6 +187,20 @@ consentDecoder =
         |> DecodeP.required "title" (Decode.dict Decode.string)
 
 
+paymentTypeDecoder : Decoder PaymentType
+paymentTypeDecoder =
+    Decode.andThen
+        (\value ->
+            case PaymentType.fromString value of
+                Just paymentType ->
+                    Decode.succeed paymentType
+
+                Nothing ->
+                    Decode.fail "Invalid payment type"
+        )
+        Decode.string
+
+
 onTariffZones : (Result () (List TariffZone) -> msg) -> Sub msg
 onTariffZones =
     remoteConfigDecoder tariffZoneDecoder >> remoteConfigTariffZones
@@ -205,6 +221,11 @@ onConsents =
     remoteConfigDecoder consentDecoder >> remoteConfigConsents
 
 
+onPaymentTypes : (Result () (List PaymentType) -> msg) -> Sub msg
+onPaymentTypes =
+    remoteConfigDecoder paymentTypeDecoder >> remoteConfigPaymentTypes
+
+
 
 -- INTERNAL
 
@@ -219,6 +240,9 @@ port remoteConfigUserProfiles : (Decode.Value -> msg) -> Sub msg
 
 
 port remoteConfigConsents : (Decode.Value -> msg) -> Sub msg
+
+
+port remoteConfigPaymentTypes : (Decode.Value -> msg) -> Sub msg
 
 
 remoteConfigDecoder : Decoder a -> (Result () (List a) -> msg) -> (Decode.Value -> msg)

--- a/src/elm/Service/Ticket.elm
+++ b/src/elm/Service/Ticket.elm
@@ -5,8 +5,9 @@ module Service.Ticket exposing
     , search
     )
 
+import Data.PaymentType as PaymentType exposing (PaymentCard(..), PaymentType(..))
 import Data.RefData exposing (UserType(..))
-import Data.Ticket exposing (Offer, PaymentStatus, PaymentType(..), Price, Reservation)
+import Data.Ticket exposing (Offer, PaymentStatus, Price, Reservation)
 import Environment exposing (Environment)
 import Http
 import Json.Decode as Decode exposing (Decoder)
@@ -250,10 +251,5 @@ reservationDecoder =
 
 
 encodePaymentType : PaymentType -> Value
-encodePaymentType paymentType =
-    case paymentType of
-        Nets ->
-            Encode.int 1
-
-        Vipps ->
-            Encode.int 2
+encodePaymentType =
+    PaymentType.toInt >> Encode.int

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -1,5 +1,6 @@
 module Shared exposing (Msg, Shared, hasCarnetTickets, hasPeriodTickets, init, subscriptions, update)
 
+import Data.PaymentType exposing (PaymentType)
 import Data.RefData exposing (Consent, DistributionChannel(..), FareProduct, Limitation, ProductType(..), TariffZone, UserProfile, UserType)
 import Data.RemoteConfig exposing (RemoteConfig)
 import List exposing (product)
@@ -14,6 +15,7 @@ type Msg
     | ReceiveFareProducts (Result () (List FareProduct))
     | ReceiveUserProfiles (Result () (List UserProfile))
     | ReceiveConsents (Result () (List Consent))
+    | ReceivePaymentTypes (Result () (List PaymentType))
     | ReceiveRemoteConfig (Result () RemoteConfig)
     | ProfileChange (Maybe Profile)
 
@@ -28,6 +30,7 @@ type alias Shared =
     , remoteConfig : RemoteConfig
     , productLimitations : List Limitation
     , consents : List Consent
+    , paymentTypes : List PaymentType
     , profile : Maybe Profile
     }
 
@@ -40,6 +43,7 @@ init =
     , userProfiles = []
     , productLimitations = []
     , consents = []
+    , paymentTypes = []
     , profile = Nothing
     , remoteConfig = RCConfig.init
     }
@@ -83,6 +87,14 @@ update msg model =
             case result of
                 Ok value ->
                     { model | consents = value }
+
+                Err _ ->
+                    model
+
+        ReceivePaymentTypes result ->
+            case result of
+                Ok value ->
+                    { model | paymentTypes = value }
 
                 Err _ ->
                     model
@@ -132,6 +144,7 @@ subscriptions =
         , RefDataService.onFareProducts ReceiveFareProducts
         , RefDataService.onUserProfiles ReceiveUserProfiles
         , RefDataService.onConsents ReceiveConsents
+        , RefDataService.onPaymentTypes ReceivePaymentTypes
         , RCConfig.onRemoteConfig ReceiveRemoteConfig
         , MiscService.onProfileChange ProfileChange
         ]

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -79,7 +79,7 @@ app.ports.bodyClass.subscribe(function (className) {
     document.body.className = className;
 });
 
-function fetchRemoteConfigData(port, key) {
+function fetchRemoteConfigData(port, key, prop) {
     if (!port) {
         return;
     }
@@ -96,7 +96,11 @@ function fetchRemoteConfigData(port, key) {
         return;
     }
 
-    port.send(data);
+    if (typeof prop === 'string' && data.hasOwnProperty(prop)) {
+        port.send(data[prop]);
+    } else {
+        port.send(data);
+    }
 }
 
 function sendRemoteConfigVatPercent(port) {
@@ -131,6 +135,7 @@ remoteConfig
             'tariff_zones'
         );
         fetchRemoteConfigData(app.ports.remoteConfigConsents, 'consents');
+        fetchRemoteConfigData(app.ports.remoteConfigPaymentTypes, 'payment_types', 'web');
         sendRemoteConfigVatPercent();
     })
     .catch((err) => {


### PR DESCRIPTION
This adds support for MasterCard and American Express, and also makes the payment types configurable from Remote Config. This way we can easily add and remove payment types without deploying new code.

Closes #337 