### PR TITLE
feat: Make screen reader spell order ids

### DIFF
--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -615,7 +615,7 @@ viewValidityWarning model =
                     , A.class "validityWarning__button"
                     , A.title "Fjern melding"
                     ]
-                    [ Icon.cross, Ui.ScreenReaderText.view "Fjern melding" ]
+                    [ Icon.cross, Ui.ScreenReaderText.onlyRead "Fjern melding" ]
                 ]
             ]
 

--- a/src/elm/Page/History.elm
+++ b/src/elm/Page/History.elm
@@ -25,6 +25,7 @@ import Task
 import Ui.Button as B
 import Ui.Expandable
 import Ui.Message as Message
+import Ui.ScreenReaderText as SR
 import Ui.Section
 import Util.Format as Format
 
@@ -294,6 +295,12 @@ viewOrder shared model order =
 
         isRefunded =
             order.state == FareContractStateRefunded
+
+        orderIdText =
+            "Ordre-ID: " ++ order.orderId
+
+        spellableOrderIdText =
+            "Ordre-ID: " ++ SR.makeSpellable order.orderId
     in
         Ui.Expandable.view
             { title = Format.date order.created ++ " - " ++ fareProduct ++ travellers
@@ -307,7 +314,7 @@ viewOrder shared model order =
                 , H.div [ A.class "metadata-list" ]
                     (if isRefunded then
                         [ H.div [] [ H.text <| "Kjøpt " ++ Format.dateTime order.created ]
-                        , H.div [] [ H.text <| "Ordre-ID: " ++ order.orderId ]
+                        , H.div [] <| SR.readAndView spellableOrderIdText orderIdText
                         , H.div [] [ H.text <| "Refundert" ]
                         ]
 
@@ -315,7 +322,7 @@ viewOrder shared model order =
                         [ H.div [] [ H.text <| "Kjøpt " ++ Format.dateTime order.created ]
                         , H.div [] [ H.text <| "Totalt kr " ++ formatTotal order.totalAmount ]
                         , H.div [] [ H.text <| "Betalt med " ++ formatPaymentType order.paymentType ]
-                        , H.div [] [ H.text <| "Ordre-ID: " ++ order.orderId ]
+                        , H.div [] <| SR.readAndView spellableOrderIdText orderIdText
                         ]
                     )
                 ]

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -397,7 +397,7 @@ viewPhoneLogin model =
             [ H.div []
                 [ H.p []
                     [ H.text "Logg inn eller opprett en ny profil med engangskode på telefonen din."
-                    , SR.view " Brukere av skjermleser anbefales innlogging med e-post."
+                    , SR.onlyRead "Brukere av skjermleser anbefales innlogging med e-post."
                     ]
                 ]
             ]

--- a/src/elm/Ui/Expandable.elm
+++ b/src/elm/Ui/Expandable.elm
@@ -6,6 +6,7 @@ import Html.Attributes as A
 import Html.Attributes.Extra as Attr
 import Html.Events as E
 import Html.Extra
+import Html.Keyed as Keyed
 import Ui.Heading
 import Ui.TextContainer
 
@@ -50,33 +51,37 @@ view { open, onOpenClick, icon, id, title } children =
             id ++ "region"
     in
         Ui.TextContainer.primary
-            [ H.section
+            [ Keyed.node "section"
                 [ A.classList classList ]
-                [ H.h3 [ A.class "ui-expandable__header" ]
-                    [ H.button
-                        [ A.class "ui-expandable__headerButton"
-                        , A.attribute "aria-expanded" (boolAsString open)
-                        , A.attribute "aria-controls" regionId
-                        , A.id id
-                        , Attr.attributeMaybe (\action -> E.onClick action) onOpenClick
+                [ ( id ++ "header"
+                  , H.h3 [ A.class "ui-expandable__header" ]
+                        [ H.button
+                            [ A.class "ui-expandable__headerButton"
+                            , A.attribute "aria-expanded" (boolAsString open)
+                            , A.attribute "aria-controls" regionId
+                            , A.id id
+                            , Attr.attributeMaybe (\action -> E.onClick action) onOpenClick
+                            ]
+                            [ viewMaybe icon
+                            , H.span [ A.class "ui-expandable__headerButton__title" ] [ Ui.Heading.componentWithEl H.span title ]
+                            , H.span [ A.class "ui-expandable__headerButton__expandText" ] [ H.text expandText ]
+                            , chevronIcon
+                            ]
                         ]
-                        [ viewMaybe icon
-                        , H.span [ A.class "ui-expandable__headerButton__title" ] [ Ui.Heading.componentWithEl H.span title ]
-                        , H.span [ A.class "ui-expandable__headerButton__expandText" ] [ H.text expandText ]
-                        , chevronIcon
+                        |> viewItem
+                  )
+                , ( regionId ++ boolAsString open
+                  , H.div
+                        [ A.classList classListContent
+                        , A.attribute "aria-labelledby" id
+                        , Attr.role "region"
+                        , A.id regionId
+                        , Attr.attributeIf (not open) (A.attribute "inert" "true")
                         ]
-                    ]
-                    |> viewItem
-                , H.div
-                    [ A.classList classListContent
-                    , A.attribute "aria-labelledby" id
-                    , Attr.role "region"
-                    , A.id regionId
-                    , Attr.attributeIf (not open) (A.attribute "inert" "true")
-                    ]
-                    (children
-                        |> List.map viewItem
-                    )
+                        (children
+                            |> List.map viewItem
+                        )
+                  )
                 ]
             ]
 

--- a/src/elm/Ui/ScreenReaderText.elm
+++ b/src/elm/Ui/ScreenReaderText.elm
@@ -1,9 +1,24 @@
-module Ui.ScreenReaderText exposing (view)
+module Ui.ScreenReaderText exposing (makeSpellable, onlyRead, onlyView, readAndView)
 
 import Html as H exposing (Html)
 import Html.Attributes as A
 
 
-view : String -> Html msg
-view text =
+onlyRead : String -> Html msg
+onlyRead text =
     H.span [ A.class "ui-srOnly" ] [ H.text text ]
+
+
+onlyView : String -> Html msg
+onlyView text =
+    H.span [ A.attribute "aria-hidden" "true" ] [ H.text text ]
+
+
+readAndView : String -> String -> List (Html msg)
+readAndView readText viewText =
+    [ onlyRead readText, onlyView viewText ]
+
+
+makeSpellable : String -> String
+makeSpellable text =
+    String.join "," <| String.split "" text

--- a/src/elm/Ui/TicketDetails.elm
+++ b/src/elm/Ui/TicketDetails.elm
@@ -19,6 +19,7 @@ import Time
 import Ui.Button as B
 import Ui.LabelItem
 import Ui.Message as Message
+import Ui.ScreenReaderText as SR
 import Ui.TextContainer
 import Util.FareContract
 import Util.Format
@@ -96,6 +97,9 @@ view shared ticketDetails onReceipt =
 
                 Nothing ->
                     True
+
+        spellableOrderId =
+            SR.makeSpellable fareContract.orderId
     in
         Ui.TextContainer.primary
             [ H.section
@@ -143,7 +147,7 @@ view shared ticketDetails onReceipt =
                     , H.div [ A.class "ui-ticketDetails__item ui-ticketDetails__item--horizontal ui-ticketDetails__item--statusLine" ]
                         [ Ui.LabelItem.viewCompact "Kjøpstidspunkt" [ H.text <| Util.Format.dateTime fareContract.created ]
                         , Ui.LabelItem.viewCompact "Betalt med" [ H.text <| formatPaymentType fareContract.paymentType ]
-                        , Ui.LabelItem.viewCompact "Ordre-ID" [ H.text fareContract.orderId ]
+                        , Ui.LabelItem.viewCompact "Ordre-ID" <| SR.readAndView spellableOrderId fareContract.orderId
                         ]
                     , B.init "Be om kvittering på e-post"
                         |> B.setDisabled missingEmail
@@ -275,6 +279,9 @@ viewActivation ( reservation, status ) =
 
                 NotCaptured ->
                     "Prosesseres... ikke gyldig enda."
+
+        spellableOrderId =
+            SR.makeSpellable reservation.orderId
     in
         Ui.TextContainer.primary
             [ H.section
@@ -290,7 +297,7 @@ viewActivation ( reservation, status ) =
                 , H.div [ A.classList classListMetadata ]
                     [ Ui.LabelItem.viewCompact
                         "Ordre-ID"
-                        [ H.text reservation.orderId ]
+                        (SR.readAndView spellableOrderId reservation.orderId)
                     ]
                 ]
             ]


### PR DESCRIPTION
Order ids were by some screen readers read as gibberish words. This
commit makes the order ids spellable by adding a comma between each
character.

Also fixes a bug where some screen readers did not register that a
expandable element was opened.