### PR TITLE
fix: Spell words by using space

### DIFF
--- a/src/elm/Ui/ScreenReaderText.elm
+++ b/src/elm/Ui/ScreenReaderText.elm
@@ -21,4 +21,4 @@ readAndView readText viewText =
 
 makeSpellable : String -> String
 makeSpellable text =
-    String.join " " <| String.split "" text
+    String.join ", " <| String.split "" text

--- a/src/elm/Ui/ScreenReaderText.elm
+++ b/src/elm/Ui/ScreenReaderText.elm
@@ -21,4 +21,4 @@ readAndView readText viewText =
 
 makeSpellable : String -> String
 makeSpellable text =
-    String.join "," <| String.split "" text
+    String.join " " <| String.split "" text


### PR DESCRIPTION
Using comma for spelling of words worked great until two or more numbers
were adjacent in the text, then the screen reader read "seven comma
seven". Now changed to using space, which the screen reader reads
correctly, although a little faster than when using comma.