### PR TITLE
fix: Remove spellable text copy bug

### DIFF
--- a/src/elm/Ui/ScreenReaderText.elm
+++ b/src/elm/Ui/ScreenReaderText.elm
@@ -21,4 +21,4 @@ readAndView readText viewText =
 
 makeSpellable : String -> String
 makeSpellable text =
-    String.join ", " <| String.split "" text
+    String.join ", " (String.split "" text) ++ ","


### PR DESCRIPTION
When copying the visible text, the last letter from the spellable screen
reader only text was also included as it were no seperators (like comma)
between the screen reader only text and the visible text.