### PR TITLE
fix: Show Intercom messenger launcher

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -724,7 +724,8 @@ if (intercomEnabled) {
     // Intercom integration
     const baseSettings = {
         'AtB-Install-Id': installId,
-        'AtB-Build-Number': elmFlags.commit
+        'AtB-Build-Number': elmFlags.commit,
+        'hide_default_launcher': false,
     };
 
     firebase.auth().onAuthStateChanged((user) => {


### PR DESCRIPTION
Overstyrer slik at Intercom messenger vises i app. I tillegg slått på at visitors får lov å starte samtaler i Intercom settings:
![Screenshot 2021-08-26 at 13 46 59](https://user-images.githubusercontent.com/675421/130957565-e877a508-c8c2-4190-9191-58d5c4ef92bd.png)

Jeg er ikke sikker på hvorfor dette må gjøres nå, men ikke tidligere. Min teori er at noe er endret av konfigurasjoner i Intercom settings, trolig for appen sin del, de siste månedene.