### PR TITLE
feat: Improve radio buttons accessibility

### DIFF
--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -71,6 +71,13 @@ Cypress.Commands.add('a11yCheck', (context, inOptions) => {
     if (inOptions !== null && inOptions.rules !== null) {
         options.rules = inOptions.rules;
     }
+    else {
+        options.rules = {}
+    }
+
+    //Added due to custom styling on radio buttons, which in reality gives two radio buttons per user choice
+    //https://github.com/AtB-AS/webshop/pull/374
+    options.rules["aria-hidden-focus"] = { enabled: false }
 
     return cy.injectAxe().then(() => {
         cy.checkA11y(

--- a/src/elm/Page/Shop/Carnet.elm
+++ b/src/elm/Page/Shop/Carnet.elm
@@ -37,7 +37,7 @@ type Msg
     | CloseShop
     | SetFromZone String
     | SetToZone String
-    | SetUser UserType Bool
+    | SetUser UserType
     | ShowView MainView
     | UpdateZone Time.Zone
     | CloseSummary
@@ -117,7 +117,7 @@ update msg env model shared =
                 , TaskUtil.doTask FetchOffers
                 )
 
-        SetUser userType _ ->
+        SetUser userType ->
             PageUpdater.fromPair
                 ( { model | users = [ ( userType, 1 ) ] }
                 , TaskUtil.doTask FetchOffers

--- a/src/elm/Page/Shop/CommonViews.elm
+++ b/src/elm/Page/Shop/CommonViews.elm
@@ -23,7 +23,7 @@ import Util.Maybe
 import Util.Status exposing (Status(..))
 
 
-viewUserProfiles : String -> CommonModel a -> (UserType -> Bool -> msg) -> Shared -> Html msg
+viewUserProfiles : String -> CommonModel a -> (UserType -> msg) -> Shared -> Html msg
 viewUserProfiles defaultProduct model onUserSelect shared =
     let
         product =
@@ -36,7 +36,7 @@ viewUserProfiles defaultProduct model onUserSelect shared =
             |> Radio.viewGroup "Reisende"
 
 
-viewUserProfile : CommonModel a -> (UserType -> Bool -> msg) -> UserProfile -> Html msg
+viewUserProfile : CommonModel a -> (UserType -> msg) -> UserProfile -> Html msg
 viewUserProfile model onUserSelect userProfile =
     let
         isCurrent =

--- a/src/elm/Page/Shop/Period.elm
+++ b/src/elm/Page/Shop/Period.elm
@@ -45,10 +45,10 @@ type Msg
     | ReceiveOffers (Result Http.Error (List Offer))
     | ReceiveFareContracts (Result Decode.Error (List FareContract))
     | CloseShop
-    | SetProduct String Bool
+    | SetProduct String
     | SetFromZone String
     | SetToZone String
-    | SetUser UserType Bool
+    | SetUser UserType
     | ShowView MainView
     | SetTime String
     | SetDate String
@@ -139,7 +139,7 @@ update msg env model shared =
         OnLeavePage ->
             PageUpdater.init { model | summary = Nothing }
 
-        SetProduct product _ ->
+        SetProduct product ->
             PageUpdater.fromPair
                 ( { model | product = Just product, users = maybeResetUsers shared product model.users }
                 , TaskUtil.doTask FetchOffers
@@ -165,7 +165,7 @@ update msg env model shared =
                     , TaskUtil.doTask FetchOffers
                     )
 
-        SetUser userType _ ->
+        SetUser userType ->
             PageUpdater.fromPair
                 ( { model | users = [ ( userType, 1 ) ] }
                 , TaskUtil.doTask FetchOffers
@@ -635,13 +635,13 @@ viewStart model =
                 |> Radio.setTitle "Kjøpstidspunkt"
                 |> Radio.setName "traveltime"
                 |> Radio.setChecked (not isFutureSelected)
-                |> Radio.setOnCheck (Just <| \_ -> SetTravelDateTime TravelNow)
+                |> Radio.setOnCheck (Just <| SetTravelDateTime TravelNow)
                 |> Radio.view
             , Radio.init "travel-future"
                 |> Radio.setTitle "Velg dato og tid"
                 |> Radio.setName "traveltime"
                 |> Radio.setChecked isFutureSelected
-                |> Radio.setOnCheck (Just <| \_ -> SetTravelDateTime <| TravelFuture Nothing)
+                |> Radio.setOnCheck (Just <| SetTravelDateTime <| TravelFuture Nothing)
                 |> Radio.view
             ]
         , Html.Extra.viewIf isFutureSelected <|

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -27,6 +27,7 @@ import Ui.LoadingText
 import Ui.Message
 import Ui.Section as Section
 import Util.Format
+import Util.Maybe as MaybeUtil
 import Util.PhoneNumber
 import Util.Status exposing (Status(..))
 import Util.Time as TimeUtil
@@ -388,7 +389,7 @@ paymentTypeRadio model paymentType =
         |> Radio.setTitle (PaymentType.format paymentType)
         |> Radio.setName "paymentType"
         |> Radio.setChecked (model.paymentSelection == NonRecurring paymentType)
-        |> Radio.setOnCheck (Just <| \_ -> SetPaymentSelection <| NonRecurring paymentType)
+        |> Radio.setOnCheck (Just <| SetPaymentSelection <| NonRecurring paymentType)
         |> Radio.view
 
 
@@ -429,18 +430,26 @@ recurringPaymentRadio model recurringPayment =
         title =
             PaymentType.format recurringPayment.paymentType ++ ", **** " ++ recurringPayment.maskedPan
 
+        expirationMonth =
+            TimeUtil.isoStringToCardExpirationMonth model.query.timeZone recurringPayment.expiresAt
+
         expireString =
-            recurringPayment.expiresAt
-                |> TimeUtil.isoStringToCardExpirationMonth model.query.timeZone
-                |> Maybe.map (String.append "Utløpsdato ")
+            Maybe.map (String.append "Utløpsdato ") expirationMonth
+
+        ariaLabel =
+            PaymentType.format recurringPayment.paymentType
+                ++ " som slutter på "
+                ++ recurringPayment.maskedPan
+                ++ MaybeUtil.mapWithDefault (\exp -> " som utløper " ++ exp) "" expirationMonth
     in
         Radio.init (String.fromInt id)
             |> Radio.setTitle title
             |> Radio.setSubtitle expireString
+            |> Radio.setAriaLabel (Just ariaLabel)
             |> Radio.setName "paymentType"
             |> Radio.setIcon (Just <| PaymentType.toIcon recurringPayment.paymentType)
             |> Radio.setChecked (model.paymentSelection == Recurring id)
-            |> Radio.setOnCheck (Just <| \_ -> SetPaymentSelection <| Recurring id)
+            |> Radio.setOnCheck (Just <| SetPaymentSelection <| Recurring id)
             |> Radio.view
 
 

--- a/src/elm/Ui/Input/Radio.elm
+++ b/src/elm/Ui/Input/Radio.elm
@@ -137,7 +137,13 @@ view { id, name, title, icon, onCheck, checked, subtitle, ariaLabel, attributes 
                     ++ attributes
                 )
                 []
-            , H.label [ A.for id, A.class "ui-input-radio", A.attribute "aria-labelledby" labelId, A.attribute "role" "radio" ]
+            , H.label
+                [ A.for id
+                , A.class "ui-input-radio"
+                , A.attribute "aria-labelledby" labelId
+                , A.attribute "role" "radio"
+                , A.attribute "aria-checked" (boolToString checked)
+                ]
                 [ H.div [ A.class "ui-input-radio__content", A.attribute "aria-hidden" "true" ]
                     [ SR.onlyReadWithId (Maybe.withDefault title ariaLabel) labelId
                     , H.span [ A.class "ui-input-radio__box" ] []
@@ -161,3 +167,12 @@ view { id, name, title, icon, onCheck, checked, subtitle, ariaLabel, attributes 
                     ]
                 ]
             ]
+
+
+boolToString : Bool -> String
+boolToString bool =
+    if bool then
+        "true"
+
+    else
+        "false"

--- a/src/elm/Ui/Input/Radio.elm
+++ b/src/elm/Ui/Input/Radio.elm
@@ -1,6 +1,7 @@
 module Ui.Input.Radio exposing
     ( Radio
     , init
+    , setAriaLabel
     , setAttributes
     , setChecked
     , setIcon
@@ -16,9 +17,11 @@ module Ui.Input.Radio exposing
 
 import Html as H exposing (Attribute, Html)
 import Html.Attributes as A
+import Html.Attributes.Extra as Attr
 import Html.Events as E
 import Html.Extra
 import Ui.Group
+import Ui.ScreenReaderText as SR
 import Ui.TextContainer as Text exposing (TextColor(..), TextContainer(..))
 
 
@@ -27,9 +30,10 @@ type alias Radio msg =
     , name : String
     , title : String
     , subtitle : Maybe String
+    , ariaLabel : Maybe String
     , icon : Maybe (Html msg)
     , checked : Bool
-    , onCheck : Maybe (Bool -> msg)
+    , onCheck : Maybe msg
     , attributes : List (H.Attribute msg)
     }
 
@@ -40,6 +44,7 @@ init id =
     , name = ""
     , title = ""
     , subtitle = Nothing
+    , ariaLabel = Nothing
     , icon = Nothing
     , checked = False
     , onCheck = Nothing
@@ -67,6 +72,11 @@ setSubtitle subtitle opts =
     { opts | subtitle = subtitle }
 
 
+setAriaLabel : Maybe String -> Radio msg -> Radio msg
+setAriaLabel ariaLabel opts =
+    { opts | ariaLabel = ariaLabel }
+
+
 setIcon : Maybe (Html msg) -> Radio msg -> Radio msg
 setIcon icon opts =
     { opts | icon = icon }
@@ -77,7 +87,7 @@ setChecked checked opts =
     { opts | checked = checked }
 
 
-setOnCheck : Maybe (Bool -> msg) -> Radio msg -> Radio msg
+setOnCheck : Maybe msg -> Radio msg -> Radio msg
 setOnCheck onCheck opts =
     { opts | onCheck = onCheck }
 
@@ -108,47 +118,46 @@ viewLabelGroup title children =
 
 
 view : Radio msg -> Html msg
-view { id, name, title, icon, onCheck, checked, subtitle, attributes } =
-    H.div []
-        [ H.input
-            ([ A.type_ "radio"
-             , A.id id
-             , A.name name
-             , A.class "ui-input-radio__input"
-             , maybeOnCheck onCheck
-             , A.checked checked
-             ]
-                ++ attributes
-            )
-            []
-        , H.label [ A.for id, A.class "ui-input-radio" ]
-            [ H.span [ A.class "ui-input-radio__box" ] []
-            , H.span [ A.class "ui-input-radio__title" ]
-                [ H.span [] [ H.text title ]
-                , Html.Extra.viewMaybe
-                    (\t ->
-                        H.span
-                            [ A.class "ui-input-radio__subtitle"
-                            ]
-                            [ Text.textContainer H.span (Just Text.SecondaryColor) <| Text.Tertiary [ H.text t ] ]
-                    )
-                    subtitle
-                ]
-            , Html.Extra.viewMaybe
-                (\t ->
-                    H.span [ A.class "ui-input-radio__icon" ]
-                        [ t ]
+view { id, name, title, icon, onCheck, checked, subtitle, ariaLabel, attributes } =
+    let
+        labelId =
+            id ++ "-label"
+    in
+        H.div []
+            [ H.input
+                ([ A.type_ "radio"
+                 , A.id id
+                 , A.name name
+                 , A.class "ui-input-radio__input"
+                 , Attr.attributeMaybe (always >> E.onCheck) onCheck
+                 , A.checked checked
+                 , A.attribute "aria-labelledby" labelId
+                 , A.attribute "aria-hidden" "true"
+                 ]
+                    ++ attributes
                 )
-                icon
+                []
+            , H.label [ A.for id, A.class "ui-input-radio", A.attribute "aria-labelledby" labelId, A.attribute "role" "radio" ]
+                [ H.div [ A.class "ui-input-radio__content", A.attribute "aria-hidden" "true" ]
+                    [ SR.onlyReadWithId (Maybe.withDefault title ariaLabel) labelId
+                    , H.span [ A.class "ui-input-radio__box" ] []
+                    , H.span [ A.class "ui-input-radio__title" ]
+                        [ H.span [] [ H.text title ]
+                        , Html.Extra.viewMaybe
+                            (\t ->
+                                H.span
+                                    [ A.class "ui-input-radio__subtitle"
+                                    ]
+                                    [ Text.textContainer H.span (Just Text.SecondaryColor) <| Text.Tertiary [ H.text t ] ]
+                            )
+                            subtitle
+                        ]
+                    , Html.Extra.viewMaybe
+                        (\t ->
+                            H.span [ A.class "ui-input-radio__icon" ]
+                                [ t ]
+                        )
+                        icon
+                    ]
+                ]
             ]
-        ]
-
-
-maybeOnCheck : Maybe (Bool -> msg) -> Attribute msg
-maybeOnCheck maybeAction =
-    case maybeAction of
-        Just action ->
-            E.onCheck action
-
-        Nothing ->
-            A.classList []

--- a/src/elm/Ui/ScreenReaderText.elm
+++ b/src/elm/Ui/ScreenReaderText.elm
@@ -1,4 +1,4 @@
-module Ui.ScreenReaderText exposing (makeSpellable, onlyRead, onlyView, readAndView)
+module Ui.ScreenReaderText exposing (makeSpellable, onlyRead, onlyReadWithId, onlyView, readAndView)
 
 import Html as H exposing (Html)
 import Html.Attributes as A
@@ -7,6 +7,11 @@ import Html.Attributes as A
 onlyRead : String -> Html msg
 onlyRead text =
     H.span [ A.class "ui-srOnly" ] [ H.text text ]
+
+
+onlyReadWithId : String -> String -> Html msg
+onlyReadWithId text id =
+    H.span [ A.id id, A.class "ui-srOnly" ] [ H.text text ]
 
 
 onlyView : String -> Html msg

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -592,6 +592,10 @@
     background: var(--colors-background_3-backgroundColor);
     color: var(--colors-background_3-color);
 }
+.ui-input-radio__content {
+    display: flex;
+    width: 100%;
+}
 .ui-input-radio__input {
     clip: rect(0 0 0 0);
     clip-path: inset(100%);


### PR DESCRIPTION
Made the hidden original radio button input not selectable for screen
reader cursor, making the label not be read twice.

Also removed required Bool parameter for radio onCheck event, as it was
uneccesary since a radio button may never be unchecked.

Added an optional aria label which may be passed to a radio button.