### PR TITLE
feat: Remove edit button when editing EditSection

### DIFF
--- a/src/elm/Ui/Input/EditSection.elm
+++ b/src/elm/Ui/Input/EditSection.elm
@@ -122,12 +122,6 @@ editSection children { accessibilityName, editButtonData, onEdit, inEditMode, bu
                     , H.div [ A.class "ui-editSection__container" ]
                         [ iconElement
                         , H.div [ A.class "ui-editSection__content" ] (children True)
-                        , B.init editText
-                            |> B.setIcon (Just editIcon)
-                            |> B.setOnClick onEdit
-                            |> B.setDisabled True
-                            |> B.setAttributes [ A.class "ui-editSection__editButton ui-editSection__editButton--hidden", A.tabindex -1 ]
-                            |> B.tertiaryCompact
                         ]
                     , H.div [ A.class "ui-editSection__fieldset__buttonGroup" ] <|
                         Maybe.withDefault [] buttonGroup

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -864,10 +864,6 @@ a.ui-button--link,
     margin-left: auto;
     font-weight: normal;
 }
-.ui-editSection__editButton--hidden {
-    visibility: hidden;
-    pointer-events: none;
-}
 .ui-editSection__container {
     display: flex;
     align-items: flex-end;


### PR DESCRIPTION
When the edit button was placed under the text content of the edit
section, the destructive group was placed even further down, even
though the edit button was not visible. This looked strange,
especially on mobile devices.