### PR TITLE
feat: Remove empty notifications div

### DIFF
--- a/src/elm/Ui/GlobalNotifications.elm
+++ b/src/elm/Ui/GlobalNotifications.elm
@@ -17,11 +17,10 @@ notifications messages =
             H.div
                 [ A.class "ui-notifications" ]
                 (messages
-                    |> List.map .content
                     |> List.map
-                        (\e ->
+                        (\msg ->
                             Ui.Section.init
                                 |> Ui.Section.setMarginBottom True
-                                |> Ui.Section.viewWithOptions [ e ]
+                                |> Ui.Section.viewWithOptions [ msg.content ]
                         )
                 )

--- a/src/elm/Ui/GlobalNotifications.elm
+++ b/src/elm/Ui/GlobalNotifications.elm
@@ -2,20 +2,26 @@ module Ui.GlobalNotifications exposing (notifications)
 
 import Html as H exposing (Html)
 import Html.Attributes as A
+import Html.Extra
 import Notification exposing (Notification)
 import Ui.Section
 
 
 notifications : List (Notification msg) -> Html msg
 notifications messages =
-    H.div
-        [ A.class "ui-notifications" ]
-        (messages
-            |> List.map .content
-            |> List.map
-                (\e ->
-                    Ui.Section.init
-                        |> Ui.Section.setMarginBottom True
-                        |> Ui.Section.viewWithOptions [ e ]
+    case messages of
+        [] ->
+            Html.Extra.nothing
+
+        _ ->
+            H.div
+                [ A.class "ui-notifications" ]
+                (messages
+                    |> List.map .content
+                    |> List.map
+                        (\e ->
+                            Ui.Section.init
+                                |> Ui.Section.setMarginBottom True
+                                |> Ui.Section.viewWithOptions [ e ]
+                        )
                 )
-        )


### PR DESCRIPTION
When there was no notifications, the parent div was still present with
its paddings. This parent div blocked half the header, making the header
logo and hamburger button hard to click on mobile. This was especially
present on older Android versions, where the hamburger menu was almost
impossible to click.