### PR TITLE
feat: Polite announcement of valid messages

### DIFF
--- a/src/elm/Ui/Message.elm
+++ b/src/elm/Ui/Message.elm
@@ -79,7 +79,7 @@ statusToAttribute status =
         Error _ ->
             Just <| A.attribute "role" "alert"
 
-        _ ->
+        Info _ ->
             Nothing
 
 

--- a/src/elm/Ui/Message.elm
+++ b/src/elm/Ui/Message.elm
@@ -73,6 +73,9 @@ statusToAttribute status =
         Warning _ ->
             Just <| A.attribute "aria-live" "polite"
 
+        Valid _ ->
+            Just <| A.attribute "aria-live" "polite"
+
         Error _ ->
             Just <| A.attribute "role" "alert"
 


### PR DESCRIPTION
Valid messages are most often used as global notifications when a
action was completed successfully. These announcements should be
announced to users using screen readers.