### PR TITLE
feat: Screen reader improvements for Group expandables

### DIFF
--- a/src/elm/Ui/AccessibleFieldset.elm
+++ b/src/elm/Ui/AccessibleFieldset.elm
@@ -8,7 +8,7 @@ view : String -> List (Html msg) -> Html msg
 view accessibilityName children =
     H.fieldset [ A.class "ui-accessibleFieldset" ]
         [ H.legend
-            [ A.class "ui-accessibleFieldset__legend" ]
+            [ A.class "ui-accessibleFieldset__legend", A.attribute "aria-hidden" "true" ]
             [ H.text accessibilityName ]
         , H.div [ A.class "ui-accessibleFieldset__container" ]
             children

--- a/src/elm/Ui/Group.elm
+++ b/src/elm/Ui/Group.elm
@@ -9,6 +9,7 @@ import Html.Extra
 import Ui.LabelItem
 import Ui.ScreenReaderText as SR
 import Ui.TextContainer
+import Util.Maybe as MaybeUtil
 
 
 type alias Group msg =
@@ -51,7 +52,10 @@ view { open, readonly, onOpenClick, icon, id, editTextSuffix, title, value } chi
                 Icon.upArrow
 
         ariaLabel =
-            title ++ ", " ++ Maybe.withDefault "" value ++ ", " ++ editText
+            title
+                ++ MaybeUtil.mapWithDefault ((++) ", ") "" value
+                ++ ", "
+                ++ editText
 
         regionId =
             id ++ "region"

--- a/src/elm/Ui/Group.elm
+++ b/src/elm/Ui/Group.elm
@@ -5,8 +5,9 @@ import Html as H exposing (Html)
 import Html.Attributes as A
 import Html.Attributes.Extra as Attr
 import Html.Events as E
+import Html.Extra
 import Ui.LabelItem
-import Ui.Section
+import Ui.ScreenReaderText as SR
 import Ui.TextContainer
 
 
@@ -25,11 +26,6 @@ type alias Group msg =
 view : Group msg -> List (Html msg) -> Html msg
 view { open, readonly, onOpenClick, icon, id, editTextSuffix, title, value } children =
     let
-        classList =
-            [ ( "ui-group", True )
-            , ( "ui-group--open", open )
-            ]
-
         classListContent =
             [ ( "ui-group__content", True )
             , ( "ui-group__content--open", open )
@@ -39,56 +35,58 @@ view { open, readonly, onOpenClick, icon, id, editTextSuffix, title, value } chi
             Icon.viewMonochrome Icon.edit
 
         editText =
-            if not open then
-                H.span [ A.class "ui-group__headerButton__editText" ]
-                    [ H.span [ A.class "ui-group__headerButton__editText__text" ] [ H.text <| "Endre " ++ editTextSuffix ]
+            "Endre " ++ editTextSuffix
+
+        editTextComponent =
+            if readonly then
+                Html.Extra.nothing
+
+            else if not open then
+                H.span [ A.class "ui-group__headerButton__content__editText" ]
+                    [ H.span [ A.class "ui-group__headerButton__content__editText__text" ] [ H.text editText ]
                     , editIcon
                     ]
 
             else
                 Icon.upArrow
 
+        ariaLabel =
+            title ++ ", " ++ Maybe.withDefault "" value ++ ", " ++ editText
+
         regionId =
             id ++ "region"
     in
         Ui.TextContainer.primary
-            [ if readonly then
-                Ui.Section.viewWithIcon (Icon.viewLargeMonochrome icon)
-                    [ Ui.Section.viewLabelItem title
-                        [ H.text <| Maybe.withDefault "" value
+            [ H.section
+                [ A.class "ui-group" ]
+                [ H.div [ A.class "ui-group__icon" ] [ Icon.viewLargeMonochrome icon ]
+                , H.div [ A.class "ui-group__innerContainer" ]
+                    [ H.button
+                        [ A.class "ui-group__headerButton"
+                        , A.disabled readonly
+                        , A.attribute "aria-expanded" (boolAsString open)
+                        , A.attribute "aria-controls" regionId
+                        , A.id id
+                        , Attr.attributeMaybe (\action -> E.onClick action) onOpenClick
                         ]
-                    ]
-
-              else
-                H.section
-                    [ A.classList classList ]
-                    [ H.div [ A.class "ui-group__icon" ] [ Icon.viewLargeMonochrome icon ]
-                    , H.div [ A.class "ui-group__innerContainer" ]
-                        [ H.h3 [ A.class "ui-group__header" ]
-                            [ H.button
-                                [ A.class "ui-group__headerButton"
-                                , A.disabled readonly
-                                , A.attribute "aria-expanded" (boolAsString open)
-                                , A.attribute "aria-controls" regionId
-                                , A.id id
-                                , Attr.attributeMaybe (\action -> E.onClick action) onOpenClick
-                                ]
-                                [ Ui.LabelItem.viewInline title [ H.text <| Maybe.withDefault "" value ]
-                                , editText
-                                ]
+                        [ SR.onlyRead ariaLabel
+                        , H.div [ A.class "ui-group__headerButton__content", A.attribute "aria-hidden" "true" ]
+                            [ Ui.LabelItem.viewInline title [ H.text <| Maybe.withDefault "" value ]
+                            , editTextComponent
                             ]
-                        , H.div
-                            [ A.classList classListContent
-                            , A.attribute "aria-labelledby" id
-                            , Attr.role "region"
-                            , A.id regionId
-                            , Attr.attributeIf (not open) (A.attribute "inert" "true")
-                            ]
-                            (children
-                                |> List.map viewItem
-                            )
                         ]
+                    , H.div
+                        [ A.classList classListContent
+                        , A.attribute "aria-labelledby" id
+                        , Attr.role "region"
+                        , A.id regionId
+                        , Attr.attributeIf (not open) (A.attribute "inert" "true")
+                        ]
+                        (children
+                            |> List.map viewItem
+                        )
                     ]
+                ]
             ]
 
 

--- a/src/elm/Ui/Input/Radio.elm
+++ b/src/elm/Ui/Input/Radio.elm
@@ -23,6 +23,7 @@ import Html.Extra
 import Ui.Group
 import Ui.ScreenReaderText as SR
 import Ui.TextContainer as Text exposing (TextColor(..), TextContainer(..))
+import Util.Maybe as MaybeUtil
 
 
 type alias Radio msg =
@@ -101,7 +102,9 @@ viewGroup : String -> List (Html msg) -> Html msg
 viewGroup hiddenTitle children =
     H.fieldset [ A.class "ui-input-radioGroup" ]
         (H.legend
-            [ A.class "ui-input-radioGroup__legend ui-input-radioGroup__legend--hidden" ]
+            [ A.class "ui-input-radioGroup__legend ui-input-radioGroup__legend--hidden"
+            , A.attribute "aria-hidden" "true"
+            ]
             [ H.text hiddenTitle ]
             :: List.map Ui.Group.viewItem children
         )
@@ -122,6 +125,9 @@ view { id, name, title, icon, onCheck, checked, subtitle, ariaLabel, attributes 
     let
         labelId =
             id ++ "-label"
+
+        defaultAriaLabel =
+            title ++ MaybeUtil.mapWithDefault ((++) ", ") "" subtitle
     in
         H.div []
             [ H.input
@@ -145,7 +151,7 @@ view { id, name, title, icon, onCheck, checked, subtitle, ariaLabel, attributes 
                 , A.attribute "aria-checked" (boolToString checked)
                 ]
                 [ H.div [ A.class "ui-input-radio__content", A.attribute "aria-hidden" "true" ]
-                    [ SR.onlyReadWithId (Maybe.withDefault title ariaLabel) labelId
+                    [ SR.onlyReadWithId (Maybe.withDefault defaultAriaLabel ariaLabel) labelId
                     , H.span [ A.class "ui-input-radio__box" ] []
                     , H.span [ A.class "ui-input-radio__title" ]
                         [ H.span [] [ H.text title ]

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -214,44 +214,40 @@
 .ui-group__headerButton {
     font-family: var(--font-main);
     background: none;
-    display: flex;
     width: 100%;
-    border: 0;
-    justify-content: space-between;
-    align-items: center;
     color: var(--text-colors-primary);
-    text-align: left;
-    cursor: pointer;
 
     transition: all 150ms ease-in-out;
     border: var(--border-width-medium) solid transparent;
     // Remove border from padding.
     padding: calc(var(--spacings-xLarge) - 2 * var(--border-width-medium));
+}
+.ui-group__headerButton:enabled:hover {
+    background: var(--colors-background_2-backgroundColor);
+    color: var(--colors-background_2-color);
+    cursor: pointer;
+}
+.ui-group__headerButton:enabled:focus {
+    outline: 0;
+    border: var(--border-width-medium) solid
+        var(--colors-primary_2-backgroundColor);
+}
+.ui-group__headerButton:enabled:active {
+    background: var(--colors-background_3-backgroundColor);
+    color: var(--colors-background_3-color);
+}
+.ui-group__headerButton__content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    text-align: left;
 
     svg,
     path {
         fill: currentColor;
     }
 }
-.ui-group__headerButton:hover {
-    background: var(--colors-background_2-backgroundColor);
-    color: var(--colors-background_2-color);
-}
-.ui-group__headerButton:focus {
-    outline: 0;
-    border: var(--border-width-medium) solid
-        var(--colors-primary_2-backgroundColor);
-}
-.ui-group__headerButton:active {
-    background: var(--colors-background_3-backgroundColor);
-    color: var(--colors-background_3-color);
-}
-.ui-group__headerButton__title {
-    display: block;
-    flex: 1;
-    text-align: left;
-}
-.ui-group__headerButton__editText {
+.ui-group__headerButton__content__editText {
     display: flex;
 
     svg {
@@ -260,7 +256,7 @@
 }
 
 @media (max-width: 500px) {
-    .ui-group__headerButton__editText__text {
+    .ui-group__headerButton__content__editText__text {
         position: absolute;
         clip: rect(0 0 0 0);
     }


### PR DESCRIPTION
The group section was a h3 header with a button as the child element.
This was not handled well by all screen readers, where some were
confused if the focused item was a header or a button. Changed the group
sections to only be buttons, and not headers.

Also some other small improvements regarding hidden fieldset legends not
being focusable by screen reader, and including the radio button
subtitle in its aria label.