### PR TITLE
feat: better feedback if invalid phone number during onboarding

### DIFF
--- a/src/elm/Page/Onboarding.elm
+++ b/src/elm/Page/Onboarding.elm
@@ -349,7 +349,7 @@ getError error =
                     |> Decode.andThen
                         (\upstreamError ->
                             case
-                                Decode.decodeString (Decode.field "shortNorwegian" Decode.string) upstreamError
+                                Decode.decodeString (Decode.field "longNorwegian" Decode.string) upstreamError
                             of
                                 Err _ ->
                                     Decode.fail "Invalid error"


### PR DESCRIPTION
Heisann!

Et bytte fra å vise feilmelding shortNorwegian til å vise longNorwegian i stedet kan løse feilen med mobilnummer på onboarding nevnt i issue #290, spesifikt denne [kommentaren](https://github.com/AtB-AS/webshop/issues/290#issuecomment-877060729).

En alternativ approach kan selvsagt være å gi ut en annen feilmelding som shortNorwegian fra server.

`{"errorCode":400,"shortNorwegian":"Ugyldig eller manglende parameter i tjenestekall","longNorwegian":"Norske telefonnummer må ha 8 siffer","shortEnglish":"Invalid or missing parameter in service call","longEnglish":"Norwegian telephone numbers must be 8 digits long"}`

![image](https://user-images.githubusercontent.com/21310942/133619875-cea5e1c1-11e2-43d2-9bc8-7ab5627a7e13.png)
