### PR TITLE
fix: Fetch vat percent from Remote Config

### DIFF
--- a/src/elm/Data/RemoteConfig.elm
+++ b/src/elm/Data/RemoteConfig.elm
@@ -1,6 +1,0 @@
-module Data.RemoteConfig exposing (RemoteConfig)
-
-
-type alias RemoteConfig =
-    { vat_percent : Int
-    }

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -589,7 +589,7 @@ offerToPrice offer =
 
 vatAmount : Float -> Shared -> Float
 vatAmount price shared =
-    (toFloat shared.remoteConfig.vat_percent / 100) * price
+    (shared.vatPercent / 100) * price
 
 
 

--- a/src/elm/Service/RemoteConfig.elm
+++ b/src/elm/Service/RemoteConfig.elm
@@ -1,37 +1,13 @@
-port module Service.RemoteConfig exposing (init, onRemoteConfig)
-
-import Data.RefData exposing (LangString(..), UserType(..))
-import Data.RemoteConfig exposing (RemoteConfig)
-import Json.Decode as Decode exposing (Decoder)
-import Json.Decode.Pipeline as DecodeP
+port module Service.RemoteConfig exposing (onVatPercent)
 
 
-init : RemoteConfig
-init =
-    { vat_percent = 6
-    }
-
-
-onRemoteConfig : (Result () RemoteConfig -> msg) -> Sub msg
-onRemoteConfig =
-    remoteConfigDecoder remoteConfigDataDecoder >> remoteConfigData
+onVatPercent : (Float -> msg) -> Sub msg
+onVatPercent =
+    remoteConfigVatPercent
 
 
 
 -- INTERNAL
 
 
-port remoteConfigData : (Decode.Value -> msg) -> Sub msg
-
-
-remoteConfigDataDecoder : Decoder RemoteConfig
-remoteConfigDataDecoder =
-    Decode.succeed RemoteConfig
-        |> DecodeP.required "vat_percent" Decode.int
-
-
-remoteConfigDecoder : Decoder a -> (Result () a -> msg) -> (Decode.Value -> msg)
-remoteConfigDecoder decoder msg =
-    Decode.decodeValue decoder
-        >> Result.mapError (\_ -> ())
-        >> msg
+port remoteConfigVatPercent : (Float -> msg) -> Sub msg

--- a/src/elm/Shared.elm
+++ b/src/elm/Shared.elm
@@ -2,12 +2,11 @@ module Shared exposing (Msg, Shared, hasCarnetTickets, hasPeriodTickets, init, s
 
 import Data.PaymentType exposing (PaymentType)
 import Data.RefData exposing (Consent, DistributionChannel(..), FareProduct, Limitation, ProductType(..), TariffZone, UserProfile, UserType)
-import Data.RemoteConfig exposing (RemoteConfig)
 import List exposing (product)
 import List.Extra
 import Service.Misc as MiscService exposing (Profile)
 import Service.RefData as RefDataService
-import Service.RemoteConfig as RCConfig
+import Service.RemoteConfig as RemoteConfigService
 
 
 type Msg
@@ -16,7 +15,7 @@ type Msg
     | ReceiveUserProfiles (Result () (List UserProfile))
     | ReceiveConsents (Result () (List Consent))
     | ReceivePaymentTypes (Result () (List PaymentType))
-    | ReceiveRemoteConfig (Result () RemoteConfig)
+    | ReceiveVatPercent Float
     | ProfileChange (Maybe Profile)
 
 
@@ -27,7 +26,7 @@ type alias Shared =
     -- Available for webshop
     , availableFareProducts : List FareProduct
     , userProfiles : List UserProfile
-    , remoteConfig : RemoteConfig
+    , vatPercent : Float
     , productLimitations : List Limitation
     , consents : List Consent
     , paymentTypes : List PaymentType
@@ -45,7 +44,7 @@ init =
     , consents = []
     , paymentTypes = []
     , profile = Nothing
-    , remoteConfig = RCConfig.init
+    , vatPercent = 12
     }
 
 
@@ -99,13 +98,8 @@ update msg model =
                 Err _ ->
                     model
 
-        ReceiveRemoteConfig result ->
-            case result of
-                Ok value ->
-                    { model | remoteConfig = value }
-
-                Err _ ->
-                    model
+        ReceiveVatPercent value ->
+            { model | vatPercent = value }
 
         ProfileChange profile ->
             { model | profile = profile }
@@ -145,7 +139,7 @@ subscriptions =
         , RefDataService.onUserProfiles ReceiveUserProfiles
         , RefDataService.onConsents ReceiveConsents
         , RefDataService.onPaymentTypes ReceivePaymentTypes
-        , RCConfig.onRemoteConfig ReceiveRemoteConfig
+        , RemoteConfigService.onVatPercent ReceiveVatPercent
         , MiscService.onProfileChange ProfileChange
         ]
 

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -116,17 +116,24 @@ function fetchRemoteConfigData(port, key, prop) {
     }
 }
 
-function sendRemoteConfigVatPercent(port) {
+function fetchRemoteConfigNumber(port, key) {
     if (!port) {
         return;
     }
 
-    const value = remoteConfig.getNumber('vat_percent');
-    if (value == null) {
+    const value = getRemoteConfigString(key);
+
+    if (typeof value !== 'string' || value.length < 1) {
         return;
     }
 
-    app.ports.remoteConfigVatPercent.send(value);
+    const num = parseFloat(value);
+
+    if (isNaN(num)) {
+        return;
+    }
+
+    port.send(num);
 }
 
 // NOTE: Only change this for testing.
@@ -149,7 +156,7 @@ remoteConfig
         );
         fetchRemoteConfigData(app.ports.remoteConfigConsents, 'consents');
         fetchRemoteConfigData(app.ports.remoteConfigPaymentTypes, 'payment_types', 'web');
-        sendRemoteConfigVatPercent();
+        fetchRemoteConfigNumber(app.ports.remoteConfigVatPercent, 'vat_percent');
     })
     .catch((err) => {
         // ...


### PR DESCRIPTION
The fetching of vat percent was not working, the default value of 6 was
used by the webshop even though the value in Remote Config was 12.

Fixed this by fetching vat percent in a similar matter as the reference
data from Remote Config. 