### PR TITLE
Dynamisk setting av siteTitle i index.html

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
     <head>
-        <title><%= elmFlags.siteName %></title>
+        <title><%= elmFlags.siteTitle %></title>
 
         <link rel="manifest" href="/manifest.json" />
         <meta name="theme-color" content="#eee" />
@@ -10,13 +10,13 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="application-name" content=<%= elmFlags.siteName %> />
+        <meta name="application-name" content=<%= elmFlags.siteTitle %> />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta
             name="apple-mobile-web-app-status-bar-style"
             content="black-translucent"
         />
-        <meta name="apple-mobile-web-app-title" content=<%= elmFlags.siteName %> />
+        <meta name="apple-mobile-web-app-title" content=<%= elmFlags.siteTitle %> />
         <link rel="icon" href="/org/images/icon.svg" />
 
         <link rel="preconnect" href="https://fonts.gstatic.com" />

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
     <head>
-        <title><%= elmFlags.siteTitle %></title>
+        <title><%= elmFlags.orgConf.siteTitle %></title>
 
         <link rel="manifest" href="/manifest.json" />
         <meta name="theme-color" content="#eee" />
@@ -10,13 +10,13 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="application-name" content=<%= elmFlags.siteTitle %> />
+        <meta name="application-name" content=<%= elmFlags.orgConf.siteTitle %> />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta
             name="apple-mobile-web-app-status-bar-style"
             content="black-translucent"
         />
-        <meta name="apple-mobile-web-app-title" content=<%= elmFlags.siteTitle %> />
+        <meta name="apple-mobile-web-app-title" content=<%= elmFlags.orgConf.siteTitle %> />
         <link rel="icon" href="/org/images/icon.svg" />
 
         <link rel="preconnect" href="https://fonts.gstatic.com" />
@@ -78,7 +78,7 @@
         </script>
         <% } %>
     </head>
-    <body <%= elmFlags.orgId %>>
+    <body <%= elmFlags.orgConf.orgId %>>
         <noscript>
             <h2>I need to execute some JS to work 😞</h2>
         </noscript>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="no">
     <head>
-        <title>AtB Nettbutikk</title>
+        <title><%= elmFlags.siteName %></title>
 
         <link rel="manifest" href="/manifest.json" />
         <meta name="theme-color" content="#eee" />
@@ -10,13 +10,13 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="application-name" content="AtB Nettbutikk" />
+        <meta name="application-name" content=<%= elmFlags.siteName %> />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta
             name="apple-mobile-web-app-status-bar-style"
             content="black-translucent"
         />
-        <meta name="apple-mobile-web-app-title" content="AtB Nettbutikk" />
+        <meta name="apple-mobile-web-app-title" content=<%= elmFlags.siteName %> />
         <link rel="icon" href="/org/images/icon.svg" />
 
         <link rel="preconnect" href="https://fonts.gstatic.com" />

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -78,7 +78,7 @@
         </script>
         <% } %>
     </head>
-    <body <%= elmFlags.orgConf.orgId %>>
+    <body>
         <noscript>
             <h2>I need to execute some JS to work 😞</h2>
         </noscript>

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -10,7 +10,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { Elm } from '../elm/Main';
 import './navigation';
 
-const appConfig = require(`/orgs/${elmFlags.orgId}.json`)
+const appConfig = require(`/orgs/${elmFlags.orgConf.orgId}.json`)
 const MAX_RETRY_ATTEMPTS = 3;
 
 if (!elmFlags.isDevelopment && 'serviceWorker' in navigator) {

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -10,7 +10,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { Elm } from '../elm/Main';
 import './navigation';
 
-const appConfig = require(`/orgs/${elmFlags.orgConf.orgId}.json`)
 const MAX_RETRY_ATTEMPTS = 3;
 
 if (!elmFlags.isDevelopment && 'serviceWorker' in navigator) {
@@ -67,7 +66,6 @@ const app = Elm.Main.init({
             showValidityWarning:
                 localStorage.getItem('hideValidityWarning') != 'yes',
             localUrl: window.location.origin,
-            orgConf: appConfig
         },
         elmFlags
     )

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -368,7 +368,7 @@ const commonConfig = {
                 siteTitle: possibleSiteTitles[orgId],
                 languageSwitcher: languageSwitcher || isDevelopment,
                 version: gitDescribe(),
-                commit: gitCommitHash(),
+                commit: gitCommitHash()
             }),
             gaTrackingId: JSON.stringify(
                 process.env.GA_TRACKING_ID || localConfig.gaTrackingId

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -363,7 +363,8 @@ const commonConfig = {
                 orgId: orgId,
                 languageSwitcher: languageSwitcher || isDevelopment,
                 version: gitDescribe(),
-                commit: gitCommitHash()
+                commit: gitCommitHash(),
+                siteName: "OOS Nettbutikk"
             }),
             gaTrackingId: JSON.stringify(
                 process.env.GA_TRACKING_ID || localConfig.gaTrackingId

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -275,10 +275,7 @@ const isDevelopment = TARGET_ENV === development;
 const languageSwitcher = getLanguageSwitcher(localConfig);
 const enableDebug = TARGET_ENV === development || TARGET_ENV === debug;
 const orgId = getOrgIdConfig(localConfig);
-const possibleSiteTitles = {
-    AtB: "AtB Nettbutikk",
-    nfk: "Reis Nettbutikk"
-}
+const appConfig = require(`./orgs/${orgId}.json`)
 
 // Common Webpack config.  Everything here will be used in both the
 // development and production environments.
@@ -364,11 +361,10 @@ const commonConfig = {
                 baseUrl: getBaseUrl(localConfig, 'baseUrl'),
                 ticketUrl: getBaseUrl(localConfig, 'ticketUrl'),
                 refDataUrl: getBaseUrl(localConfig, 'refDataUrl'),
-                orgId: orgId,
-                siteTitle: possibleSiteTitles[orgId],
                 languageSwitcher: languageSwitcher || isDevelopment,
                 version: gitDescribe(),
-                commit: gitCommitHash()
+                commit: gitCommitHash(),
+                orgConf: appConfig
             }),
             gaTrackingId: JSON.stringify(
                 process.env.GA_TRACKING_ID || localConfig.gaTrackingId

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -221,6 +221,8 @@ function getOrgIdConfig(config) {
         );
     }
 
+    console.log(config)
+
     return orgId;
 }
 
@@ -275,6 +277,10 @@ const isDevelopment = TARGET_ENV === development;
 const languageSwitcher = getLanguageSwitcher(localConfig);
 const enableDebug = TARGET_ENV === development || TARGET_ENV === debug;
 const orgId = getOrgIdConfig(localConfig);
+const possibleSiteTitles = {
+    AtB: "AtB Nettbutikk",
+    nfk: "Reis Nettbutikk"
+}
 
 // Common Webpack config.  Everything here will be used in both the
 // development and production environments.
@@ -361,10 +367,10 @@ const commonConfig = {
                 ticketUrl: getBaseUrl(localConfig, 'ticketUrl'),
                 refDataUrl: getBaseUrl(localConfig, 'refDataUrl'),
                 orgId: orgId,
+                siteTitle: possibleSiteTitles[orgId],
                 languageSwitcher: languageSwitcher || isDevelopment,
                 version: gitDescribe(),
                 commit: gitCommitHash(),
-                siteName: "OOS Nettbutikk"
             }),
             gaTrackingId: JSON.stringify(
                 process.env.GA_TRACKING_ID || localConfig.gaTrackingId

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -221,8 +221,6 @@ function getOrgIdConfig(config) {
         );
     }
 
-    console.log(config)
-
     return orgId;
 }
 


### PR DESCRIPTION
Sidetittelen på nettbutikken har tidligere vært hardkodet til AtB Nettbutikk i `index.html`, og fra og med nylig blitt dynamisk overskrevet gjennom i Elm. Denne løsningen har sørget for en liten forsinkelse før sidetittelen blir overskrevet og brukere i f.eks. Nordland kunne derfor oppleve at sidetittel er `AtB Nettbutikk` et lite sekund før tittelen blir `Reis Nettbutikk.`

Dette blir nå ordnet gjennom at mulige sidetitler finnes i `webpack.config.js` og resolves basert på orgId som er gitt til webpack.