### PR TITLE
Mer intuitiv .gitignore for static-filer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@ yarn-error.log
 .DS_Store
 .firebase
 
-src/static/*
-!src/static/common
+src/static/org
+src/static/favicon.ico

--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ yarn-error.log
 .DS_Store
 .firebase
 
+# Most organization specific static files are copied from the tracked orgs/ folders using 'yarn setup <organization>'
 src/static/org
 src/static/favicon.ico


### PR DESCRIPTION
Tidligere har `.gitignore` inneholdt en kombinasjon av ignorerte filer og tillatte filer, noe som kanskje ikke er så lesbart, og samtidig har medført at f.eks. `src/static/index.html` og `src/static/index.js` kun ble tracket siden de eksisterte før `.gitignore` sist ble endret.

Denne PR-en gjør at `.gitignore` kun inneholder de filer og mapper som faktisk skal ignoreres, noe som gjerne er mer intuitivt.