### PR TITLE
chore: updates cloud build to use env vars

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,10 +3,9 @@ steps:
   args: ['install']
 - name: 'gcr.io/cloud-builders/yarn'
   args: ['build']
+  env:
+  - 'WEBSHOP_BASE_URL=$_WEBSHOP_BASE_URL'
+  - 'WEBSHOP_FIREBASE_CONFIG=$_WEBSHOP_FIREBASE_CONFIG'
+  - 'WEBSHOP_ORG_ID=$_WEBSHOP_ORG_ID'
 - name: 'gcr.io/$PROJECT_ID/firebase'
-  args: ['deploy', '--only', 'hosting:pilot-travelcard-webshop']
-  secretEnv: ['FIREBASE_TOKEN']
-secrets:
-- kmsKeyName: 'projects/pilot-travelcard-webshop/locations/global/keyRings/firebase-token/cryptoKeys/firebase-token'
-  secretEnv:
-    FIREBASE_TOKEN: 'CiQAvtdDtdzAUzLWF2JWl3tGPuyEictuEEgF2UzbKeYm2PZEeqUSkQEAPWPe5kMbDU3TTQFCU81jPlqnR3ubQP4qgruPu6GlmTn250yrZrHlO22gRsLSPwDN1aDo+WKFdRi5mDE0aimBMVEAgZATTaPu3L9n/Jo6XZWOVtV1Lb9mjZaVjCiDuu2GHqXZTNWRcTpofsz0iruu4gOl4tsb7S6ZDRlcAvL5oaptwgwh9kthh9Ovu4SA8n5g'
+  args: ['deploy', '--project=$PROJECT_ID', '--only=hosting']


### PR DESCRIPTION
Det ligger en cloudbuild.yml fil brakk fra tidligere CI løsninger her, men egentlig så er det nyttig å ha en som er oppdatert. Slik kan f.eks NFK rulle ut enkelt i staging og prod basert på branches og bruke AtBs via GH Action på PR, så det kan gjøre regresjonstester der og.

Nå har jeg tatt utgangspunkt i guide fra https://cloud.google.com/build/docs/deploying-builds/deploy-firebase

Der setter det opp tilganger til Firebase via IAM, men jeg har også sett tidligere eksempler og som vari cloudbuild her fra før der det blir generert opp en kryptert token som manuelt settes inn. Jeg kunne ikke finne en umiddelbar måte å støtte flere miljøer med bruk av krypterte secrets, og eksempler jeg fant viste til flere yaml-filer. Det syns jeg blir en lite skalerbar løsning. Så forslaget er å følge det som vises i guide her, men jeg har ikke gjort noe vurdering på sikkerhetsissue eller bad practice på det.