### PR TITLE
fix: html meta syntax for title injection from lodash templates

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,13 +10,19 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
-        <meta name="application-name" content=<%= elmFlags.orgConf.siteTitle %> />
+        <meta
+            name="application-name"
+            content="<%= elmFlags.orgConf.siteTitle %>"
+        />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta
             name="apple-mobile-web-app-status-bar-style"
             content="black-translucent"
         />
-        <meta name="apple-mobile-web-app-title" content=<%= elmFlags.orgConf.siteTitle %> />
+        <meta
+            name="apple-mobile-web-app-title"
+            content="<%= elmFlags.orgConf.siteTitle %>"
+        />
         <link rel="icon" href="/org/images/icon.svg" />
 
         <link rel="preconnect" href="https://fonts.gstatic.com" />


### PR DESCRIPTION
Det er en "feil" med måten title blir injected på her. Det blir satt uten anførselstegn. Det er teknisk sett OK uten XHTML strict mode, men det er sårbart ut i fra hva innholdet til title kan være. Burde være anførselstegn rundt verdien.