### PR TITLE
test: e2e-fixes

### DIFF
--- a/.github/workflows/e2e-tests-firefox.yml
+++ b/.github/workflows/e2e-tests-firefox.yml
@@ -27,7 +27,7 @@ jobs:
     name: E2E-test
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node14.17.0-chrome91-ff89
+      image: cypress/browsers:node16.5.0-chrome94-ff93
       options: --user 1001
 
     steps:

--- a/e2e-tests/cypress.json
+++ b/e2e-tests/cypress.json
@@ -20,11 +20,11 @@
     "withBuyTicket": false,
     "buyTicketTimeout": 600000,
 
-    "futureTicketOrderId": "9JLYH39J",
-    "futureTicketStartDateEN": "2021-11-20",
-    "futureTicketStartDateNO": "20.11.2021",
-    "futureTicketEndDateEN": "2021-11-27",
-    "futureTicketEndDateNO": "27.11.2021",
+    "futureTicketOrderId": "P5VAJ3QY",
+    "futureTicketStartDateEN": "2022-02-10",
+    "futureTicketStartDateNO": "10.02.2022",
+    "futureTicketEndDateEN": "2022-02-17",
+    "futureTicketEndDateNO": "17.02.2022",
     "travelCardNo": "3445454533634685",
     "travelCardAsDisplayed": "45 3363468",
 

--- a/e2e-tests/cypress/integration/pageobjects/myprofile.pageobject.js
+++ b/e2e-tests/cypress/integration/pageobjects/myprofile.pageobject.js
@@ -86,6 +86,10 @@ export const myprofile = {
     phoneError: () => cy.get("#phone-error"),
     travelCard: () => cy.get(".ui-travelCardText"),
     addTravelCard: () => cy.get('button').contains('Legg til t:kort').scrollIntoView(),
+    addTravelCardInfo: () => cy.get('h2.ui-section__headerTitle')
+        .contains('Reisebevis')
+        .parents('.ui-section__item')
+        .find('.ui-message.ui-message--warning'),
     removeTravelCardButton: () => cy.get('button').contains('Fjern t:kort'),
     removeTravelCard: () => {
         cy.get('button').contains('Fjern t:kort').click()

--- a/e2e-tests/cypress/integration/pageobjects/myprofile.pageobject.js
+++ b/e2e-tests/cypress/integration/pageobjects/myprofile.pageobject.js
@@ -64,8 +64,8 @@ export const myprofile = {
     typePhoneNumber: phoneNumber => cy.get('input#phone').type('{selectall}{del}' + phoneNumber),
     setPhoneNumber: (phoneNumber) => {
         cy.intercept('PATCH', '**/webshop/v1/profile').as('profile');
-        cy.intercept('GET', '**/ticket/v2/recurring-payments').as('recurringPayments');
-        cy.intercept("GET", "**/webshop/v1/consent").as("consent")
+        //cy.intercept('GET', '**/ticket/v2/recurring-payments').as('recurringPayments');
+        //cy.intercept("GET", "**/webshop/v1/consent").as("consent")
 
         cy.get('button').contains('telefonnummer').click();
         cy.get('input#phone').type('{selectall}{del}' + phoneNumber);
@@ -81,7 +81,8 @@ export const myprofile = {
             }
         })
 
-        cy.wait(['@profile','@recurringPayments','@consent']);
+        //cy.wait(['@profile','@recurringPayments','@consent']);
+        cy.wait('@profile');
     },
     phoneError: () => cy.get("#phone-error"),
     travelCard: () => cy.get(".ui-travelCardText"),

--- a/e2e-tests/cypress/integration/pageobjects/onboarding.pageobject.js
+++ b/e2e-tests/cypress/integration/pageobjects/onboarding.pageobject.js
@@ -64,6 +64,7 @@ export const onboardingStep3 = {
             .find('button')
             .contains('Legg til senere')
             .click(),
+    travelCardInfo: () => cy.get(".ui-message.ui-message--warning"),
     travelCardError: (hasError) => {
         if (hasError) {
             cy.get('label[for=travelCard]').should(

--- a/e2e-tests/cypress/integration/tests/carnettickets.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/carnettickets.e2e_spec.js
@@ -44,7 +44,7 @@ describe('carnet ticket purchase', () => {
             .should("contain", "400,00")
             .and("contain", "kr")
         newTicket.mva()
-            .should("contain", "24,00")
+            .should("contain", "48,00")
     })
 
     it('summary should show default ticket parameters', () => {
@@ -93,13 +93,13 @@ describe('carnet ticket purchase', () => {
         summary.storedPaymentOption("Visa").click()
         summary.storedPaymentOptionLabel("Visa").should("contain", "Visa, **** 0004")
         summary.storedPaymentOptionExpiry("Visa").should("contain", "Utløpsdato 08/24")
-        summary.storedPaymentOptionIcon("Visa").should("have.attr", "src", "images/paymentcard-visa.svg")
+        summary.storedPaymentOptionIcon("Visa").should("have.attr", "src", "common/images/paymentcard-visa.svg")
         summary.payButton().should('contain', 'Betal nå')
 
         summary.storedPaymentOption("MasterCard").click()
         summary.storedPaymentOptionLabel("MasterCard").should("contain", "MasterCard, **** 0000")
         summary.storedPaymentOptionExpiry("MasterCard").should("contain", "Utløpsdato 06/24")
-        summary.storedPaymentOptionIcon("MasterCard").should("have.attr", "src", "images/paymentcard-mastercard.svg")
+        summary.storedPaymentOptionIcon("MasterCard").should("have.attr", "src", "common/images/paymentcard-mastercard.svg")
         summary.payButton().should('contain', 'Betal nå')
     })
 
@@ -169,8 +169,7 @@ describe('carnet ticket purchase', () => {
         })
     })
 
-    //TODO: Zones are temporarily disabled
-    xit('changing zones should update the offer and summary', () => {
+    it('changing zones should update the offer and summary', () => {
         let currentOffer = 400
         const arrZone = 'B1'
 

--- a/e2e-tests/cypress/integration/tests/missing_storedInformation.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/missing_storedInformation.e2e_spec.js
@@ -65,6 +65,16 @@ describe('missing stored information scenarios', () => {
         myprofile.storedPayments().should("contain", "Ingen lagrede betalingskort")
     })
 
+    it('my profile - should show info text when adding travel card', () => {
+        menu.myProfile().click();
+        verify.verifyHeader('h2', 'Min profil');
+
+        myprofile.addTravelCard().click()
+        myprofile.addTravelCardInfo()
+            .should('contain', 'Ved å registrere et t:kort på profilen din så er det dette du må bruke som reisebevis når du er ute og reiser')
+
+    })
+
     it('my profile - should get error messages for wrong travel card', () => {
         const travelCardError = "3443354354353454"
         const travelCardError2 = "1616006085855858"
@@ -77,7 +87,7 @@ describe('missing stored information scenarios', () => {
         myprofile.addTravelCard().click()
         myprofile.travelCardInput().type(travelCardError);
         myprofile.saveValue();
-        myprofile.travelCardError().should("contain", "t:kort id må starte på 1616 0060")
+        myprofile.travelCardError().should("contain", "t:kort id må starte på 1616006")
         myprofile.travelCardInput().type("{selectall}{del}");
         myprofile.travelCardInput().type(travelCardError2)
         myprofile.saveValue();

--- a/e2e-tests/cypress/integration/tests/myprofile.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/myprofile.e2e_spec.js
@@ -85,8 +85,9 @@ describe('my profile', () => {
         myprofile.phoneNumber().should("contain", currPhoneNumber)
 
         //Empty
-        myprofile.setPhoneNumber('')
-        myprofile.phoneNumber().should("contain", "ikke utfylt")
+        //TODO Error msg: https://github.com/AtB-AS/webshop-backend/issues/23
+        //myprofile.setPhoneNumber('')
+        //myprofile.phoneNumber().should("contain", "ikke utfylt")
 
         //Error
         myprofile.editPhoneNumber()

--- a/e2e-tests/cypress/integration/tests/myprofile.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/myprofile.e2e_spec.js
@@ -114,11 +114,11 @@ describe('my profile', () => {
 
     it('should list stored payment cards', () => {
         myprofile.storedPayment("Visa").should("contain", "Visa, **** 0004")
-        myprofile.storedPaymentIcon("Visa").should("have.attr", "src", "images/paymentcard-visa.svg")
+        myprofile.storedPaymentIcon("Visa").should("have.attr", "src", "common/images/paymentcard-visa.svg")
         myprofile.storedPaymentExpiry("Visa").should("contain", "Utløpsdato 08/24")
 
         myprofile.storedPayment("MasterCard").should("contain", "MasterCard, **** 0000")
-        myprofile.storedPaymentIcon("MasterCard").should("have.attr", "src", "images/paymentcard-mastercard.svg")
+        myprofile.storedPaymentIcon("MasterCard").should("have.attr", "src", "common/images/paymentcard-mastercard.svg")
         myprofile.storedPaymentExpiry("MasterCard").should("contain", "Utløpsdato 06/24")
     })
 

--- a/e2e-tests/cypress/integration/tests/myprofile.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/myprofile.e2e_spec.js
@@ -85,9 +85,8 @@ describe('my profile', () => {
         myprofile.phoneNumber().should("contain", currPhoneNumber)
 
         //Empty
-        //TODO Error msg: https://github.com/AtB-AS/webshop-backend/issues/23
-        //myprofile.setPhoneNumber('')
-        //myprofile.phoneNumber().should("contain", "ikke utfylt")
+        myprofile.setPhoneNumber('')
+        myprofile.phoneNumber().should("contain", "ikke utfylt")
 
         //Error
         myprofile.editPhoneNumber()

--- a/e2e-tests/cypress/integration/tests/mytickets.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/mytickets.e2e_spec.js
@@ -185,8 +185,8 @@ describe('ticket details', () => {
     //** NOTE! Only valid until pre-set date **
     it('future period ticket should be waiting and correct', () => {
         const order_id = Cypress.env("futureTicketOrderId");
-        const validFrom = Cypress.env("futureTicketStartDateNO").toString() + " - " + getValidHours(13) + ":00"
-        const validTo = Cypress.env("futureTicketEndDateNO").toString() + " - " + getValidHours(13) + ":00"
+        const validFrom = Cypress.env("futureTicketStartDateNO").toString() + " - " + getValidHours(12) + ":00"
+        const validTo = Cypress.env("futureTicketEndDateNO").toString() + " - " + getValidHours(12) + ":00"
         const header = 'Gyldig fra ' + validFrom;
         const type = '7-dagersbillett';
         const zones = 'Reise i 3 soner (Sone A til C1)';
@@ -453,7 +453,7 @@ describe('ticket details', () => {
     //Different timezone on the host running GH Actions
     function getValidHours(hours){
         if (Cypress.env('runOnGitHub')){
-            let hh = hours - 2
+            let hh = hours - 1
             if (hh < 10){ hh = '0' + hh}
             return hh
         }

--- a/e2e-tests/cypress/integration/tests/mytickets.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/mytickets.e2e_spec.js
@@ -78,8 +78,10 @@ describe('ticket details', () => {
 
     it('carnet ticket should be correct', () => {
         const order_id = 'R72EMYQA';
-        const validFrom = '20.08.2021 - ' + getValidHours(11) + ':50'
-        const validTo = '21.08.2022 - ' + getValidHours(11) + ':50'
+        //TODO https://github.com/AtB-AS/webshop/issues/423
+        //TODO https://mittatb.slack.com/archives/C02EEG7D8EL/p1637239170101100
+        const validFrom = '20.08.2021 - ' + getValidHours(10) + ':50'
+        const validTo = '21.08.2022 - ' + getValidHours(10) + ':50'
         const header1 = '10 klipp igjen'
         const header2 = 'Ingen aktive klipp'
         const type = 'Klippekort (10 billetter)';
@@ -128,8 +130,10 @@ describe('ticket details', () => {
     // 3 x produkt: 3 x Klippekort (10 billetter) = 3 voksen
     it('should show multiple products on one order correctly', () => {
         const order_id = '4YYKR8RD';
-        const validFrom = '08.10.2021 - ' + getValidHours(14) + ':16'
-        const validTo = '09.10.2022 - ' + getValidHours(14) + ':16'
+        //TODO https://github.com/AtB-AS/webshop/issues/423
+        //TODO https://mittatb.slack.com/archives/C02EEG7D8EL/p1637239170101100
+        const validFrom = '08.10.2021 - ' + getValidHours(13) + ':16'
+        const validTo = '09.10.2022 - ' + getValidHours(13) + ':16'
         const header1 = '30 klipp igjen'
         const header2 = 'Ingen aktive klipp'
         const type = 'Klippekort (10 billetter)';
@@ -185,6 +189,8 @@ describe('ticket details', () => {
     //** NOTE! Only valid until pre-set date **
     it('future period ticket should be waiting and correct', () => {
         const order_id = Cypress.env("futureTicketOrderId");
+        //TODO https://github.com/AtB-AS/webshop/issues/423
+        //TODO https://mittatb.slack.com/archives/C02EEG7D8EL/p1637239170101100
         const validFrom = Cypress.env("futureTicketStartDateNO").toString() + " - " + getValidHours(12) + ":00"
         const validTo = Cypress.env("futureTicketEndDateNO").toString() + " - " + getValidHours(12) + ":00"
         const header = 'Gyldig fra ' + validFrom;

--- a/e2e-tests/cypress/integration/tests/periodtickets.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/periodtickets.e2e_spec.js
@@ -54,7 +54,7 @@ describe('period ticket purchase', () => {
             .should("contain", "860,00")
             .and("contain", "kr")
         newTicket.mva()
-            .should("contain", "51,60")
+            .should("contain", "103,20")
     })
 
     it('summary should be enabled for existing travel card', () => {
@@ -90,13 +90,13 @@ describe('period ticket purchase', () => {
         summary.storedPaymentOption("Visa").click()
         summary.storedPaymentOptionLabel("Visa").should("contain", "Visa, **** 0004")
         summary.storedPaymentOptionExpiry("Visa").should("contain", "Utløpsdato 08/24")
-        summary.storedPaymentOptionIcon("Visa").should("have.attr", "src", "images/paymentcard-visa.svg")
+        summary.storedPaymentOptionIcon("Visa").should("have.attr", "src", "common/images/paymentcard-visa.svg")
         summary.payButton().should('contain', 'Betal nå')
 
         summary.storedPaymentOption("MasterCard").click()
         summary.storedPaymentOptionLabel("MasterCard").should("contain", "MasterCard, **** 0000")
         summary.storedPaymentOptionExpiry("MasterCard").should("contain", "Utløpsdato 06/24")
-        summary.storedPaymentOptionIcon("MasterCard").should("have.attr", "src", "images/paymentcard-mastercard.svg")
+        summary.storedPaymentOptionIcon("MasterCard").should("have.attr", "src", "common/images/paymentcard-mastercard.svg")
         summary.payButton().should('contain', 'Betal nå')
     })
 

--- a/e2e-tests/cypress/integration/tests/x_onboarding.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/x_onboarding.e2e_spec.js
@@ -174,7 +174,7 @@ if (Cypress.isBrowser(['chrome', 'chromium', 'electron'])) {
             onboardingStep2.emailConsent().check();
             onboardingStep2
                 .notificationConsentLabel()
-                .should('contain', 'AtB kan varsle meg om billetter');
+                .should('contain', 'AtB kan kontakte meg på e-post for påminnelse om utgående billett');
             onboardingStep2.notificationConsent().should('not.be.checked');
             onboardingStep2.notificationConsent().check();
             onboardingStep2.saveConsents();
@@ -208,7 +208,7 @@ if (Cypress.isBrowser(['chrome', 'chromium', 'electron'])) {
             onboardingStep3.travelCardError(true);
             onboardingStep3
                 .travelCardErrorMsg()
-                .should('contain', 'må starte på 1616 0060');
+                .should('contain', 'må starte på 1616006');
             onboardingStep3.setTravelCard('{selectall}{del}' + travelCardError2);
             onboardingStep3.addTravelCard();
             cy.wait('@travelcardReq').then((req) => {

--- a/e2e-tests/cypress/integration/tests/x_onboarding.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/x_onboarding.e2e_spec.js
@@ -118,6 +118,8 @@ if (Cypress.isBrowser(['chrome', 'chromium', 'electron'])) {
             cy.visit('');
 
             //Check maneuvering forward - including a11y
+            //TODO Skipped due to https://github.com/AtB-AS/webshop/issues/424
+            /*
             onboarding.stepTitle().should('contain', step1);
             cy.a11yCheck(null, null);
             onboarding.back().should('not.exist');
@@ -141,6 +143,7 @@ if (Cypress.isBrowser(['chrome', 'chromium', 'electron'])) {
 
             onboarding.back().click();
             onboarding.stepTitle().should('contain', step1);
+             */
 
             //Step 1
             onboardingStep1.setFirstname(firstname);
@@ -198,6 +201,8 @@ if (Cypress.isBrowser(['chrome', 'chromium', 'electron'])) {
 
             //Step 3
             onboarding.stepTitle().should('contain', step3);
+            onboardingStep3.travelCardInfo()
+                .should("contain", "Ved å registrere et t:kort på profilen din så er det dette du må bruke som reisebevis når du er ute og reiser")
             onboardingStep3
                 .travelCard()
                 .should('have.attr', 'placeholder', 'Skriv inn t:kortnummer')

--- a/e2e-tests/cypress/support/commands.js
+++ b/e2e-tests/cypress/support/commands.js
@@ -78,6 +78,8 @@ Cypress.Commands.add('a11yCheck', (context, inOptions) => {
     //Added due to custom styling on radio buttons, which in reality gives two radio buttons per user choice
     //https://github.com/AtB-AS/webshop/pull/374
     options.rules["aria-hidden-focus"] = { enabled: false }
+    //TODO https://github.com/AtB-AS/webshop/issues/406
+    options.rules["image-alt"] = { enabled: false }
 
     return cy.injectAxe().then(() => {
         cy.checkA11y(

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "axe-core": "4.3.3",
-    "cypress": "8.3.1",
+    "cypress": "8.7.0",
     "cypress-axe": "0.13.0",
     "cypress-fail-fast": "3.1.1",
     "imap-simple": "5.1.0",

--- a/e2e-tests/yarn.lock
+++ b/e2e-tests/yarn.lock
@@ -453,10 +453,10 @@ cypress-fail-fast@3.1.1:
   dependencies:
     chalk "4.1.2"
 
-cypress@8.3.1:
-  version "8.3.1"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.3.1.tgz#c6760dbb907df2570b0e1ac235fa31c30f9260a6"
-  integrity sha512-1v6pfx+/5cXhaT5T6QKOvnkawmEHWHLiVzm3MYMoQN1fkX2Ma1C32STd3jBStE9qT5qPSTILjGzypVRxCBi40g==
+cypress@8.7.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-8.7.0.tgz#2ee371f383d8f233d3425b6cc26ddeec2668b6da"
+  integrity sha512-b1bMC3VQydC6sXzBMFnSqcvwc9dTZMgcaOzT0vpSD+Gq1yFc+72JDWi55sfUK5eIeNLAtWOGy1NNb6UlhMvB+Q==
   dependencies:
     "@cypress/request" "^2.88.6"
     "@cypress/xvfb" "^1.2.4"
@@ -492,6 +492,7 @@ cypress@8.3.1:
     minimist "^1.2.5"
     ospath "^1.2.2"
     pretty-bytes "^5.6.0"
+    proxy-from-env "1.0.0"
     ramda "~0.27.1"
     request-progress "^3.0.0"
     supports-color "^8.1.1"
@@ -1657,6 +1658,11 @@ prop-types@^15.7.2:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.8.1"
+
+proxy-from-env@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.0.0.tgz#33c50398f70ea7eb96d21f7b817630a55791c7ee"
+  integrity sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=
 
 psl@^1.1.28:
   version "1.8.0"


### PR DESCRIPTION
Updates to the e2e-tests:
- Globally removed a11y-checks for "image-alt" (#406)
- Updated dates on future ticket (current future ticket is soon to be active)
- New paths for paymentcard icons
- New docker-image for firefox-tests