### PR TITLE
remove English AtB dictionary link

### DIFF
--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -333,10 +333,6 @@ view env model appInfo =
                     |> B.setElement H.a
                     |> B.setAttributes [ A.href "https://www.nfk.no/" ]
                     |> B.link
-                , B.init "For our English speaking travellers"
-                    |> B.setElement H.a
-                    |> B.setAttributes [ A.href "https://www.atb.no/ny-nettbutikk/key-words-and-phrases-article17509-2740.html" ]
-                    |> B.link
                 ]
             ]
 


### PR DESCRIPTION
Fjerner denne linken i NFK sin webshop:

![image](https://user-images.githubusercontent.com/21310942/143858018-8b311bd0-afff-4d41-80c4-16f99932a243.png)

Burde dette skje dynamisk?
