### PR TITLE
Dynamiske lenker for oversettelser og intro til nye reisetjenester

### DIFF
--- a/orgs/atb.json
+++ b/orgs/atb.json
@@ -3,5 +3,6 @@
     "siteTitle": "AtB Nettbutikk",
     "zoneMapUrl": "https://atb.no/soner",
     "privacyDeclarationUrl": "https://beta.atb.no/private-policy",
+    "englishTranslationsUrl": "https://www.snowman.no/ny-nettbutikk/key-words-and-phrases-article17509-2740.html",
     "travelCardValidPrefix": "1616006"
 }

--- a/orgs/atb.json
+++ b/orgs/atb.json
@@ -4,5 +4,6 @@
     "zoneMapUrl": "https://atb.no/soner",
     "privacyDeclarationUrl": "https://beta.atb.no/private-policy",
     "englishTranslationsUrl": "https://www.snowman.no/ny-nettbutikk/key-words-and-phrases-article17509-2740.html",
+    "newTravelServicesUrl": "https://www.atb.no/vi-oppgraderer/",
     "travelCardValidPrefix": "1616006"
 }

--- a/orgs/atb.json
+++ b/orgs/atb.json
@@ -3,7 +3,7 @@
     "siteTitle": "AtB Nettbutikk",
     "zoneMapUrl": "https://atb.no/soner",
     "privacyDeclarationUrl": "https://beta.atb.no/private-policy",
-    "englishTranslationsUrl": "https://www.snowman.no/ny-nettbutikk/key-words-and-phrases-article17509-2740.html",
+    "englishTranslationsUrl": "https://www.atb.no/ny-nettbutikk/key-words-and-phrases-article17509-2740.html",
     "newTravelServicesUrl": "https://www.atb.no/vi-oppgraderer/",
     "travelCardValidPrefix": "1616006"
 }

--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -3,5 +3,6 @@
     "siteTitle": "Reis Nettbutikk",
     "zoneMapUrl": "https://static1.squarespace.com/static/60019c06f8f42f6c20a066eb/t/604f636f8509920229480e08/1615815536923/Sonekart+Nordland.pdf",
     "privacyDeclarationUrl": "https://www.reisnordland.no/personvern-og-cookies",
+    "englishTranslationsUrl": "nej",
     "travelCardValidPrefix": ""
 }

--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -3,6 +3,5 @@
     "siteTitle": "Reis Nettbutikk",
     "zoneMapUrl": "https://static1.squarespace.com/static/60019c06f8f42f6c20a066eb/t/604f636f8509920229480e08/1615815536923/Sonekart+Nordland.pdf",
     "privacyDeclarationUrl": "https://www.reisnordland.no/personvern-og-cookies",
-    "englishTranslationsUrl": "nej",
     "travelCardValidPrefix": ""
 }

--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -3,5 +3,6 @@
     "siteTitle": "Reis Nettbutikk",
     "zoneMapUrl": "https://static1.squarespace.com/static/60019c06f8f42f6c20a066eb/t/604f636f8509920229480e08/1615815536923/Sonekart+Nordland.pdf",
     "privacyDeclarationUrl": "https://www.reisnordland.no/personvern-og-cookies",
+    "newTravelServicesUrl": "https://www.reisnordland.no/ny-app",
     "travelCardValidPrefix": ""
 }

--- a/src/elm/Base.elm
+++ b/src/elm/Base.elm
@@ -15,5 +15,6 @@ type alias AppInfo =
     , zoneMapUrl : String
     , privacyDeclarationUrl : String
     , englishTranslationsUrl : Maybe String
+    , newTravelServicesUrl : Maybe String
     , travelCardValidPrefix : String
     }

--- a/src/elm/Base.elm
+++ b/src/elm/Base.elm
@@ -14,5 +14,6 @@ type alias AppInfo =
     , orgId : OrgId
     , zoneMapUrl : String
     , privacyDeclarationUrl : String
+    , englishTranslationsUrl: String
     , travelCardValidPrefix : String
     }

--- a/src/elm/Base.elm
+++ b/src/elm/Base.elm
@@ -14,6 +14,6 @@ type alias AppInfo =
     , orgId : OrgId
     , zoneMapUrl : String
     , privacyDeclarationUrl : String
-    , englishTranslationsUrl: String
+    , englishTranslationsUrl : Maybe String
     , travelCardValidPrefix : String
     }

--- a/src/elm/Data/Organization.elm
+++ b/src/elm/Data/Organization.elm
@@ -10,6 +10,7 @@ type alias OrganizationConfiguration =
     , siteTitle : String
     , zoneMapUrl : String
     , privacyDeclarationUrl : String
+    , englishTranslationsUrl: String
     , travelCardValidPrefix : String
     }
 
@@ -21,6 +22,7 @@ orgConfDecoder =
         |> DecodeP.required "siteTitle" Decode.string
         |> DecodeP.required "zoneMapUrl" Decode.string
         |> DecodeP.required "privacyDeclarationUrl" Decode.string
+        |> DecodeP.required "englishTranslationsUrl" Decode.string
         |> DecodeP.required "travelCardValidPrefix" Decode.string
 
 

--- a/src/elm/Data/Organization.elm
+++ b/src/elm/Data/Organization.elm
@@ -10,7 +10,7 @@ type alias OrganizationConfiguration =
     , siteTitle : String
     , zoneMapUrl : String
     , privacyDeclarationUrl : String
-    , englishTranslationsUrl: String
+    , englishTranslationsUrl : Maybe String
     , travelCardValidPrefix : String
     }
 
@@ -22,7 +22,7 @@ orgConfDecoder =
         |> DecodeP.required "siteTitle" Decode.string
         |> DecodeP.required "zoneMapUrl" Decode.string
         |> DecodeP.required "privacyDeclarationUrl" Decode.string
-        |> DecodeP.required "englishTranslationsUrl" Decode.string
+        |> DecodeP.optional "englishTranslationsUrl" (Decode.map Just Decode.string) Nothing
         |> DecodeP.required "travelCardValidPrefix" Decode.string
 
 

--- a/src/elm/Data/Organization.elm
+++ b/src/elm/Data/Organization.elm
@@ -11,6 +11,7 @@ type alias OrganizationConfiguration =
     , zoneMapUrl : String
     , privacyDeclarationUrl : String
     , englishTranslationsUrl : Maybe String
+    , newTravelServicesUrl : Maybe String
     , travelCardValidPrefix : String
     }
 
@@ -23,6 +24,7 @@ orgConfDecoder =
         |> DecodeP.required "zoneMapUrl" Decode.string
         |> DecodeP.required "privacyDeclarationUrl" Decode.string
         |> DecodeP.optional "englishTranslationsUrl" (Decode.map Just Decode.string) Nothing
+        |> DecodeP.optional "newTravelServicesUrl" (Decode.map Just Decode.string) Nothing
         |> DecodeP.required "travelCardValidPrefix" Decode.string
 
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -293,6 +293,7 @@ init flags url navKey =
             , zoneMapUrl = flags.orgConf.zoneMapUrl
             , privacyDeclarationUrl = flags.orgConf.privacyDeclarationUrl
             , englishTranslationsUrl = flags.orgConf.englishTranslationsUrl
+            , newTravelServicesUrl = flags.orgConf.newTravelServicesUrl
             , travelCardValidPrefix = flags.orgConf.travelCardValidPrefix
             }
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -630,7 +630,7 @@ view model =
                             viewPage model
 
                         Nothing ->
-                            LoginPage.view model.environment model.login model.appInfo
+                            LoginPage.view model.environment model.appInfo model.login
                                 |> H.map LoginMsg
             ]
         ]

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -292,6 +292,7 @@ init flags url navKey =
             , orgId = flags.orgConf.orgId
             , zoneMapUrl = flags.orgConf.zoneMapUrl
             , privacyDeclarationUrl = flags.orgConf.privacyDeclarationUrl
+            , englishTranslationsUrl = flags.orgConf.englishTranslationsUrl
             , travelCardValidPrefix = flags.orgConf.travelCardValidPrefix
             }
 
@@ -628,7 +629,7 @@ view model =
                             viewPage model
 
                         Nothing ->
-                            LoginPage.view model.environment model.login
+                            LoginPage.view model.environment model.login model.appInfo
                                 |> H.map LoginMsg
             ]
         ]

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -25,6 +25,7 @@ import Ui.Section
 import Util.PhoneNumber
 import Util.Validation as V exposing (FormError, ValidationErrors)
 import Validate exposing (Valid)
+import Base exposing (AppInfo)
 
 
 type LoginMethod
@@ -294,8 +295,8 @@ focusBox id =
         |> Maybe.withDefault Cmd.none
 
 
-view : Environment -> Model -> Html Msg
-view env model =
+view : Environment -> Model -> AppInfo -> Html Msg
+view env model appInfo =
     if model.showInfoStep then
         H.div [ A.class "page page--narrow" ]
             [ viewIllustration
@@ -324,7 +325,7 @@ view env model =
                     |> B.link
                 , B.init "For our English speaking travellers"
                     |> B.setElement H.a
-                    |> B.setAttributes [ A.href "https://www.atb.no/ny-nettbutikk/key-words-and-phrases-article17509-2740.html" ]
+                    |> B.setAttributes [ A.href appInfo.englishTranslationsUrl ]
                     |> B.link
                 ]
             ]

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -319,10 +319,15 @@ view env model appInfo =
                         |> B.setOnClick (Just HideInfoStep)
                         |> B.primary B.Primary_2
                     ]
-                , B.init "Les mer om AtBs nye reisetjenester her"
-                    |> B.setElement H.a
-                    |> B.setAttributes [ A.href "https://www.atb.no/vi-oppgraderer/" ]
-                    |> B.link
+                , case appInfo.newTravelServicesUrl of
+                    Just newTravelServicesUrl ->
+                        B.init "Les mer om våre nye reisetjenester her"
+                            |> B.setElement H.a
+                            |> B.setAttributes [ A.href newTravelServicesUrl ]
+                            |> B.link
+
+                    Nothing ->
+                        Html.Extra.nothing
                 , case appInfo.englishTranslationsUrl of
                     Just englishTranslationsUrl ->
                         B.init "For our English speaking travellers"

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -295,8 +295,8 @@ focusBox id =
         |> Maybe.withDefault Cmd.none
 
 
-view : Environment -> Model -> AppInfo -> Html Msg
-view env model appInfo =
+view : Environment -> AppInfo -> Model -> Html Msg
+view env appInfo model =
     if model.showInfoStep then
         H.div [ A.class "page page--narrow" ]
             [ viewIllustration

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -1,5 +1,6 @@
 module Page.Login exposing (Model, Msg(..), init, subscriptions, update, view)
 
+import Base exposing (AppInfo)
 import Browser.Dom as Dom
 import Browser.Navigation as Nav
 import Environment exposing (Environment)
@@ -25,7 +26,6 @@ import Ui.Section
 import Util.PhoneNumber
 import Util.Validation as V exposing (FormError, ValidationErrors)
 import Validate exposing (Valid)
-import Base exposing (AppInfo)
 
 
 type LoginMethod
@@ -323,10 +323,15 @@ view env model appInfo =
                     |> B.setElement H.a
                     |> B.setAttributes [ A.href "https://www.atb.no/vi-oppgraderer/" ]
                     |> B.link
-                , B.init "For our English speaking travellers"
-                    |> B.setElement H.a
-                    |> B.setAttributes [ A.href appInfo.englishTranslationsUrl ]
-                    |> B.link
+                , case appInfo.englishTranslationsUrl of
+                    Just englishTranslationsUrl ->
+                        B.init "For our English speaking travellers"
+                            |> B.setElement H.a
+                            |> B.setAttributes [ A.href englishTranslationsUrl ]
+                            |> B.link
+
+                    Nothing ->
+                        Html.Extra.nothing
                 ]
             ]
 

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -332,7 +332,7 @@ view env appInfo model =
                     Just englishTranslationsUrl ->
                         B.init "For our English speaking travellers"
                             |> B.setElement H.a
-                            |> B.setAttributes [ A.href englishTranslationsUrl ]
+                            |> B.setAttributes [ A.href englishTranslationsUrl, A.lang "en" ]
                             |> B.link
 
                     Nothing ->


### PR DESCRIPTION
Denne PR sørger for at de nederste linkene på Login-skjerm er dynamiske basert på OOS-organisasjon. (orgId)

Dersom feltene ikke finnes i `<org>.json`-filen, vises heller ikke linkteksten for det manglende feltet i nettbutikken for gitt orgId.

![image](https://user-images.githubusercontent.com/21310942/144054210-40428d3d-e303-4cb0-b074-f0316bd54b11.png)

Teksten på den øverste linken er også endret fra "Les mer om AtBs nye reisetjenester" til "Les mer om **våre** nye reisetjenester" for å kunne fungere utenfor AtB-kontekst.

Vises slik med orgId satt til nfk:
![image](https://user-images.githubusercontent.com/21310942/144064328-08baf33c-e6cd-4fb7-8d87-46fc9ef84047.png)
