### PR TITLE
Åpne personvernserklæring i ny fane

### DIFF
--- a/src/elm/Page/Account.elm
+++ b/src/elm/Page/Account.elm
@@ -963,7 +963,7 @@ viewPrivacy model shared appInfo =
             |> Validation.select Consent
             |> Html.Extra.viewMaybe Message.error
         , Ui.Section.viewPaddedItem
-            [ H.p [] [ H.a [ A.href appInfo.privacyDeclarationUrl ] [ H.text "Les vår personvernerklæring" ] ]
+            [ H.p [] [ H.a [ A.href appInfo.privacyDeclarationUrl, A.target "_blank" ] [ H.text "Les vår personvernerklæring (åpner nytt vindu)" ] ]
             ]
         ]
 


### PR DESCRIPTION
Lukker #427 

Lagt på target _blank og lagt til i lenketeksten at erklæringen åpnes i ny fane. Fremdeles dynamisk url etter orgId.

![image](https://user-images.githubusercontent.com/21310942/144076584-6ccff314-eb66-4205-b28d-f268eff9c6cf.png)
