### PR TITLE
fix: No overlapping ticket warning if empty carnet

### DIFF
--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -98,7 +98,7 @@ update msg env model shared =
                         -- Only store tickets that are valid into the future.
                         tickets =
                             fareContracts
-                                |> Util.FareContract.filterValidNow model.currentTime
+                                |> Util.FareContract.filterValidAtTime model.currentTime
                                 |> List.sortBy (.created >> .timestamp)
                                 |> List.reverse
 
@@ -375,7 +375,7 @@ viewMain shared model =
     let
         validTickets =
             model.tickets
-                |> Util.FareContract.filterValidNow model.currentTime
+                |> Util.FareContract.filterValidAtTime model.currentTime
 
         emptyResults =
             List.isEmpty validTickets && List.isEmpty model.reservations

--- a/src/elm/Page/Shop/Period.elm
+++ b/src/elm/Page/Shop/Period.elm
@@ -355,7 +355,7 @@ update msg env model shared =
                         Time.posixToMillis now
 
                     overlappingOrders =
-                        List.any (\order -> selectedTime >= order.validFrom && selectedTime < order.validTo && hasValidState order) model.orders
+                        List.length (Util.FareContract.filterValidAtTime (Time.millisToPosix selectedTime) model.orders) > 0
                 in
                     if overlappingOrders then
                         PageUpdater.init
@@ -392,7 +392,7 @@ update msg env model shared =
                         msTime
 
                     overlappingOrders =
-                        List.any (\order -> selectedTime >= order.validFrom && selectedTime < order.validTo && hasValidState order) model.orders
+                        List.length (Util.FareContract.filterValidAtTime (Time.millisToPosix selectedTime) model.orders) > 0
                 in
                     if overlappingOrders then
                         PageUpdater.fromPair

--- a/src/elm/Ui/TicketDetails.elm
+++ b/src/elm/Ui/TicketDetails.elm
@@ -211,7 +211,13 @@ viewCarnetHeader carnets classListButtonTitle now timeZone =
         validAccesses =
             carnets
                 |> List.concatMap .usedAccesses
-                |> List.filter (.endDateTime >> .timestamp >> Util.FareContract.isValid now)
+                |> List.filter
+                    (\usedAccess ->
+                        Util.FareContract.isValid
+                            now
+                            usedAccess.startDateTime.timestamp
+                            usedAccess.endDateTime.timestamp
+                    )
 
         firstValidAccess =
             List.head validAccesses

--- a/src/elm/Util/FareContract.elm
+++ b/src/elm/Util/FareContract.elm
@@ -1,20 +1,24 @@
-module Util.FareContract exposing (filterValidNow, hasValidState, isValid)
+module Util.FareContract exposing (filterValidAtTime, hasValidState, isValid)
 
 import Data.FareContract exposing (FareContract, FareContractState(..), TravelRight(..))
 import Time
 
 
-filterValidNow : Time.Posix -> List FareContract -> List FareContract
-filterValidNow now fareContracts =
+filterValidAtTime : Time.Posix -> List FareContract -> List FareContract
+filterValidAtTime timePosix fareContracts =
     fareContracts
-        |> List.filter (.validTo >> isValid now)
-        |> List.filter (hasValidTravelRight now)
+        |> List.filter (\fc -> isValid timePosix fc.validFrom fc.validTo)
+        |> List.filter (hasValidTravelRight timePosix)
         |> List.filter hasValidState
 
 
-isValid : Time.Posix -> Int -> Bool
-isValid posixNow to =
-    to >= Time.posixToMillis posixNow
+isValid : Time.Posix -> Int -> Int -> Bool
+isValid timePosix from to =
+    let
+        millis =
+            Time.posixToMillis timePosix
+    in
+        from <= millis && to >= millis
 
 
 
@@ -36,7 +40,7 @@ hasValidTravelRight now contract =
                                 carnetType.numberOfUsedAccesses < carnetType.maximumNumberOfAccesses
 
                             hasActiveAccess =
-                                List.any (.endDateTime >> .timestamp >> isValid now) carnetType.usedAccesses
+                                List.any (\tr -> isValid now tr.startDateTime.timestamp tr.endDateTime.timestamp) carnetType.usedAccesses
                         in
                             hasTicketsLeft || hasActiveAccess
 


### PR DESCRIPTION
The website showed warning that the user had existing overlapping ticket
when the existing carnet has no tickets left. The reason for this was
that just the valid from and valid to fields were checked on carnet.