### PR TITLE
Dynamisk URL i prerequisites popup

### DIFF
--- a/orgs/atb.json
+++ b/orgs/atb.json
@@ -4,6 +4,6 @@
     "zoneMapUrl": "https://atb.no/soner",
     "privacyDeclarationUrl": "https://beta.atb.no/private-policy",
     "englishTranslationsUrl": "https://www.atb.no/ny-nettbutikk/key-words-and-phrases-article17509-2740.html",
-    "newTravelServicesUrl": "https://www.atb.no/vi-oppgraderer/",
+    "newWebshopUrl": "https://www.atb.no/vi-oppgraderer/",
     "travelCardValidPrefix": "1616006"
 }

--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -3,6 +3,6 @@
     "siteTitle": "Reis Nettbutikk",
     "zoneMapUrl": "https://static1.squarespace.com/static/60019c06f8f42f6c20a066eb/t/604f636f8509920229480e08/1615815536923/Sonekart+Nordland.pdf",
     "privacyDeclarationUrl": "https://www.reisnordland.no/personvern-og-cookies",
-    "newTravelServicesUrl": "https://www.reisnordland.no/ny-app",
+    "newWebshopUrl": "https://www.reisnordland.no/ny-nettbutikk",
     "travelCardValidPrefix": ""
 }

--- a/src/elm/Base.elm
+++ b/src/elm/Base.elm
@@ -15,6 +15,6 @@ type alias AppInfo =
     , zoneMapUrl : String
     , privacyDeclarationUrl : String
     , englishTranslationsUrl : Maybe String
-    , newTravelServicesUrl : Maybe String
+    , newWebshopUrl : Maybe String
     , travelCardValidPrefix : String
     }

--- a/src/elm/Data/Organization.elm
+++ b/src/elm/Data/Organization.elm
@@ -11,7 +11,7 @@ type alias OrganizationConfiguration =
     , zoneMapUrl : String
     , privacyDeclarationUrl : String
     , englishTranslationsUrl : Maybe String
-    , newTravelServicesUrl : Maybe String
+    , newWebshopUrl : Maybe String
     , travelCardValidPrefix : String
     }
 
@@ -24,7 +24,7 @@ orgConfDecoder =
         |> DecodeP.required "zoneMapUrl" Decode.string
         |> DecodeP.required "privacyDeclarationUrl" Decode.string
         |> DecodeP.optional "englishTranslationsUrl" (Decode.map Just Decode.string) Nothing
-        |> DecodeP.optional "newTravelServicesUrl" (Decode.map Just Decode.string) Nothing
+        |> DecodeP.optional "newWebshopUrl" (Decode.map Just Decode.string) Nothing
         |> DecodeP.required "travelCardValidPrefix" Decode.string
 
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -293,7 +293,7 @@ init flags url navKey =
             , zoneMapUrl = flags.orgConf.zoneMapUrl
             , privacyDeclarationUrl = flags.orgConf.privacyDeclarationUrl
             , englishTranslationsUrl = flags.orgConf.englishTranslationsUrl
-            , newTravelServicesUrl = flags.orgConf.newTravelServicesUrl
+            , newWebshopUrl = flags.orgConf.newWebshopUrl
             , travelCardValidPrefix = flags.orgConf.travelCardValidPrefix
             }
 

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -356,7 +356,7 @@ view env appInfo model =
                 [ viewIllustration
                 , case model.step of
                     StepLogin ->
-                        viewLogin model
+                        viewLogin model appInfo
 
                     StepConfirm ->
                         viewConfirm env model
@@ -384,25 +384,25 @@ viewInfoPointWithIcon icon text =
         ]
 
 
-viewLogin : Model -> Html Msg
-viewLogin model =
+viewLogin : Model -> AppInfo -> Html Msg
+viewLogin model appInfo =
     H.form [ E.onSubmit DoLogin, A.novalidate True ] <|
         case model.loginMethod of
             PhoneMethod ->
-                viewPhoneLogin model
+                viewPhoneLogin model appInfo
 
             ResetEmailMethod ->
-                viewEmailReset model
+                viewEmailReset model appInfo
 
             RegisterEmailMethod ->
-                viewEmailRegister model
+                viewEmailRegister model appInfo
 
             EmailMethod ->
-                viewEmailLogin model
+                viewEmailLogin model appInfo
 
 
-viewPhoneLogin : Model -> List (Html Msg)
-viewPhoneLogin model =
+viewPhoneLogin : Model -> AppInfo -> List (Html Msg)
+viewPhoneLogin model appInfo =
     [ Ui.Section.view
         [ viewWelcomeIllustration
         , Ui.Section.viewPaddedItem
@@ -417,7 +417,7 @@ viewPhoneLogin model =
         , Ui.Section.viewPaddedItem
             [ H.p [] [ H.a [ Route.href <| Route.Login EmailPath ] [ H.text "Jeg vil heller bruke e-post" ] ]
             ]
-        , prerequisitesNotice
+        , prerequisitesNotice appInfo
         , B.init "Send engangskode"
             |> B.setIcon (Just Icon.rightArrow)
             |> B.setLoading model.loading
@@ -427,8 +427,8 @@ viewPhoneLogin model =
     ]
 
 
-viewEmailLogin : Model -> List (Html Msg)
-viewEmailLogin model =
+viewEmailLogin : Model -> AppInfo -> List (Html Msg)
+viewEmailLogin model appInfo =
     [ Ui.Section.view
         [ viewWelcomeIllustration
         , Ui.Section.viewPaddedItem
@@ -442,7 +442,7 @@ viewEmailLogin model =
         , Ui.Section.viewPaddedItem
             [ H.p [] [ H.a [ Route.href <| Route.Login RegisterEmailPath ] [ H.text "Opprett en ny profil" ] ]
             ]
-        , prerequisitesNotice
+        , prerequisitesNotice appInfo
         , B.init "Logg inn"
             |> B.setIcon (Just Icon.rightArrow)
             |> B.setLoading model.loading
@@ -456,13 +456,13 @@ viewEmailLogin model =
     ]
 
 
-viewEmailRegister : Model -> List (Html Msg)
-viewEmailRegister model =
+viewEmailRegister : Model -> AppInfo -> List (Html Msg)
+viewEmailRegister model appInfo =
     [ Ui.Section.view
         [ viewWelcomeIllustration
         , Ui.Section.viewPaddedItem [ H.p [] [ H.text "Opprett ny profil." ] ]
         , Ui.Section.viewItem <| viewEmailInputs "Skriv inn din e-postadresse" "Velg et passord" "new-password" model
-        , prerequisitesNotice
+        , prerequisitesNotice appInfo
         , B.init "Opprett profil"
             |> B.setIcon (Just Icon.rightArrow)
             |> B.setLoading model.loading
@@ -476,13 +476,13 @@ viewEmailRegister model =
     ]
 
 
-viewEmailReset : Model -> List (Html Msg)
-viewEmailReset model =
+viewEmailReset : Model -> AppInfo -> List (Html Msg)
+viewEmailReset model appInfo =
     [ Ui.Section.view
         [ viewWelcomeIllustration
         , Ui.Section.viewPaddedItem [ H.p [] [ H.text "Be om å tilbakestille passord på profilen." ] ]
         , Ui.Section.viewItem <| viewResetInputs model
-        , prerequisitesNotice
+        , prerequisitesNotice appInfo
         , B.init "Tilbakestill passord"
             |> B.setIcon (Just Icon.rightArrow)
             |> B.setLoading model.loading
@@ -504,11 +504,16 @@ viewWelcomeIllustration =
         ]
 
 
-prerequisitesNotice : Html msg
-prerequisitesNotice =
+prerequisitesNotice : AppInfo -> Html msg
+prerequisitesNotice appInfo =
     H.p []
         [ H.text "I en periode har nettbutikken enkelte forutsetninger. Gjør deg kjent med disse før du logger inn. "
-        , H.a [ A.href "https://www.atb.no/vi-oppgraderer", A.target "_blank", A.title "Les mer på AtBs nettside (åpner ny side)" ] [ H.text "Vi oppgraderer (åpner ny side)." ]
+        , case appInfo.newTravelServicesUrl of
+            Just newTravelServicesUrl ->
+                H.a [ A.href newTravelServicesUrl, A.target "_blank", A.title "Les mer på våre nettsider (åpner ny side)" ] [ H.text "Vi oppgraderer (åpner ny side)" ]
+
+            Nothing ->
+                Html.Extra.nothing
         ]
         |> Message.Warning
         |> Message.message

--- a/src/elm/Page/Login.elm
+++ b/src/elm/Page/Login.elm
@@ -319,11 +319,11 @@ view env appInfo model =
                         |> B.setOnClick (Just HideInfoStep)
                         |> B.primary B.Primary_2
                     ]
-                , case appInfo.newTravelServicesUrl of
-                    Just newTravelServicesUrl ->
+                , case appInfo.newWebshopUrl of
+                    Just newWebshopUrl ->
                         B.init "Les mer om våre nye reisetjenester her"
                             |> B.setElement H.a
-                            |> B.setAttributes [ A.href newTravelServicesUrl ]
+                            |> B.setAttributes [ A.href newWebshopUrl ]
                             |> B.link
 
                     Nothing ->
@@ -508,9 +508,9 @@ prerequisitesNotice : AppInfo -> Html msg
 prerequisitesNotice appInfo =
     H.p []
         [ H.text "I en periode har nettbutikken enkelte forutsetninger. Gjør deg kjent med disse før du logger inn. "
-        , case appInfo.newTravelServicesUrl of
-            Just newTravelServicesUrl ->
-                H.a [ A.href newTravelServicesUrl, A.target "_blank", A.title "Les mer på våre nettsider (åpner ny side)" ] [ H.text "Vi oppgraderer (åpner ny side)" ]
+        , case appInfo.newWebshopUrl of
+            Just newWebshopUrl ->
+                H.a [ A.href newWebshopUrl, A.target "_blank", A.title "Les mer på våre nettsider (åpner ny side)" ] [ H.text "Vi oppgraderer (åpner ny side)" ]
 
             Nothing ->
                 Html.Extra.nothing


### PR DESCRIPTION
Lenken som heter `"Vi oppgraderer"` peker til AtB Beta sine sider, men burde være dynamisk for hver organisasjon som tar i bruk nettbutikken. Derfor er lenka gjort dynamisk basert på `orgId`, og hvis feltet i `<org>.json` ikke eksisterer, fjernes lenken, men meldingen ellers består.

Har også lagt til rette for separate URLer for ny nettbutikk (`newWebshopUrl`) og ny app, foreløpig brukes kun ny nettbutikk.

![image](https://user-images.githubusercontent.com/21310942/144436392-2ff3e987-ec43-4935-84d9-6bd226c2fc36.png)