### PR TITLE
fix: Show fare contracts with future valid from

### DIFF
--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -98,7 +98,7 @@ update msg env model shared =
                         -- Only store tickets that are valid into the future.
                         tickets =
                             fareContracts
-                                |> Util.FareContract.filterValidAtTime model.currentTime
+                                |> Util.FareContract.filterNotExpiredAtTime model.currentTime
                                 |> List.sortBy .created
                                 |> List.reverse
 

--- a/src/elm/Ui/TicketDetails.elm
+++ b/src/elm/Ui/TicketDetails.elm
@@ -213,13 +213,7 @@ viewCarnetHeader carnets classListButtonTitle now timeZone =
         validAccesses =
             carnets
                 |> List.concatMap .usedAccesses
-                |> List.filter
-                    (\usedAccess ->
-                        Util.FareContract.isValid
-                            now
-                            usedAccess.startDateTime
-                            usedAccess.endDateTime
-                    )
+                |> List.filter (.endDateTime >> Util.FareContract.isNotExpired now)
 
         firstValidAccess =
             List.head validAccesses

--- a/src/elm/Util/FareContract.elm
+++ b/src/elm/Util/FareContract.elm
@@ -1,4 +1,4 @@
-module Util.FareContract exposing (filterValidAtTime, hasValidState, isValid)
+module Util.FareContract exposing (filterNotExpiredAtTime, filterValidAtTime, hasValidState, isNotExpired, isValid)
 
 import Data.FareContract exposing (FareContract, FareContractState(..), TravelRight(..))
 import Time
@@ -19,6 +19,23 @@ isValid timePosix from to =
             Time.posixToMillis timePosix
     in
         from <= millis && to >= millis
+
+
+filterNotExpiredAtTime : Time.Posix -> List FareContract -> List FareContract
+filterNotExpiredAtTime timePosix fareContracts =
+    fareContracts
+        |> List.filter (.validTo >> isNotExpired timePosix)
+        |> List.filter (hasValidTravelRight timePosix)
+        |> List.filter hasValidState
+
+
+isNotExpired : Time.Posix -> Int -> Bool
+isNotExpired timePosix to =
+    let
+        millis =
+            Time.posixToMillis timePosix
+    in
+        to >= millis
 
 
 


### PR DESCRIPTION
In the overview-screen, show fare contracts which has a future valid
from date. This was unintentionally changed in a previous issue.