### PR TITLE
fix: Show fare contracts with future valid from

### DIFF
--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -375,7 +375,7 @@ viewMain shared model =
     let
         validTickets =
             model.tickets
-                |> Util.FareContract.filterValidAtTime model.currentTime
+                |> Util.FareContract.filterNotExpiredAtTime model.currentTime
 
         emptyResults =
             List.isEmpty validTickets && List.isEmpty model.reservations


### PR DESCRIPTION
In the overview-screen, show fare contracts which has a future valid
from date. This was unintentionally changed in a previous issue.