### PR TITLE
fix: Avoid posting "+47" as phone number on register

### DIFF
--- a/src/elm/Util/PhoneNumber.elm
+++ b/src/elm/Util/PhoneNumber.elm
@@ -19,6 +19,9 @@ withDefaultCountryCode phone =
     if String.isEmpty phone then
         phone
 
+    else if String.endsWith "+47" phone then
+        ""
+
     else if String.startsWith "+" phone then
         phone
 


### PR DESCRIPTION
Som diskutert på [Slack](https://mittatb.slack.com/archives/C025NUF4WA0/p1639046753159800) er det en bug som gjør at "+47" blir sendt inn som telefonnummer, dersom man f.eks. bruker tab for å klikke seg gjennom onboardingen etter å ha autentisert med e-post. Dette har deretter ført til at onboardingen feiler med melding "Ukjent feil".

Denne PR fjerner +47 før requesten mot `/register` blir sendt inn til Firebase, dersom kun prefiks og ikke nummer finnes i input.