### PR TITLE
fix: replace nfk webshop upgrade url

### DIFF
--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -3,6 +3,6 @@
     "siteTitle": "Reis nettbutikk",
     "zoneMapUrl": "https://static1.squarespace.com/static/60019c06f8f42f6c20a066eb/t/604f636f8509920229480e08/1615815536923/Sonekart+Nordland.pdf",
     "privacyDeclarationUrl": "https://www.reisnordland.no/personvern-og-cookies",
-    "newWebshopUrl": "https://www.reisnordland.no/ny-nettbutikk",
+    "newWebshopUrl": "https://www.reisnordland.no/nettbutikk",
     "travelCardValidPrefix": ""
 }


### PR DESCRIPTION
Erstatter NFK sin link til info om oppgradering av nettbutikk. Referanse: https://jira.bouvet.no/browse/NLFKRDP-99