### PR TITLE
fix: handle spacing for every potential ui-icon components

### DIFF
--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -201,7 +201,8 @@ p + p {
     display: flex;
     align-items: center;
 
-    svg {
+    svg,
+    .ui-img-dark {
         margin-left: var(--spacings-small);
     }
     svg,
@@ -266,7 +267,8 @@ p + p {
         width: 100%;
         padding: var(--spacings-medium);
 
-        svg {
+        svg,
+        .ui-img-dark {
             margin-left: auto;
         }
     }
@@ -327,7 +329,8 @@ p + p {
 
     margin-left: auto;
 
-    svg {
+    svg,
+    .ui-img-dark {
         width: var(--icon-size-small);
         height: var(--icon-size-small);
 
@@ -406,7 +409,8 @@ p + p {
 
 .accountInfo__item {
     display: flex;
-    svg {
+    svg,
+    .ui-img-dark {
         display: block;
         margin-right: var(--spacings-medium);
     }
@@ -473,8 +477,8 @@ p + p {
     display: flex;
     align-items: center;
 
-    .ui-img-dark,
-    svg {
+    svg,
+    .ui-img-dark {
         margin: var(--spacings-large);
         display: block;
     }
@@ -486,7 +490,8 @@ p + p {
 .pageAccount__noTravelCard {
     display: flex;
 
-    svg {
+    svg,
+    .ui-img-dark {
         flex-shrink: 0;
         display: block;
         margin-right: var(--spacings-medium);

--- a/src/static/styles/ui.scss
+++ b/src/static/styles/ui.scss
@@ -5,7 +5,8 @@
 
     animation: fadeIn 350ms;
 
-    svg {
+    svg,
+    .ui-img-dark {
         width: var(--icon-size-normal);
         height: var(--icon-size-normal);
         margin-right: var(--spacings-medium);
@@ -137,7 +138,8 @@
 .ui-section__itemWithIcon__icon {
     padding: var(--spacings-xLarge);
 
-    svg {
+    svg,
+    .ui-img-dark {
         display: block;
         width: var(--ws-icon-size-xLarge);
     }
@@ -192,7 +194,8 @@
     display: block;
     padding: var(--spacings-xLarge);
 
-    svg {
+    svg,
+    .ui-img-dark {
         display: block;
     }
 }
@@ -250,7 +253,8 @@
 .ui-group__headerButton__content__editText {
     display: flex;
 
-    svg {
+    svg,
+    .ui-img-dark {
         margin-left: var(--spacings-medium);
     }
 }
@@ -463,7 +467,8 @@
     color: var(--colors-background_3-color);
 }
 .ui-ticketDetails__headerButton__icon {
-    svg {
+    svg,
+    .ui-img-dark {
         display: block;
     }
 }
@@ -492,7 +497,8 @@
 }
 
 .ui-ticketDetails__headerButton__toggleText {
-    svg {
+    svg,
+    .ui-img-dark {
         margin-left: var(--spacings-medium);
     }
 
@@ -565,7 +571,8 @@
 .ui-pageHeader__back {
     order: 1;
 
-    svg {
+    svg,
+    .ui-img-dark {
         margin-right: var(--spacings-medium);
     }
 }
@@ -751,7 +758,8 @@ a.ui-button {
 .ui-button__icon {
     display: block;
 
-    svg {
+    svg,
+    .ui-img-dark {
         display: block;
     }
 }
@@ -905,7 +913,8 @@ a.ui-button--link,
 .ui-editSection__horizontalGroup__icon {
     padding: var(--spacings-xLarge);
 
-    svg {
+    svg,
+    .ui-img-dark {
         display: block;
     }
 }
@@ -923,7 +932,8 @@ a.ui-button--link,
         fill: currentColor;
     }
 
-    svg {
+    svg,
+    .ui-img-dark {
         margin-right: var(--spacings-medium);
     }
 }
@@ -943,7 +953,8 @@ a.ui-button--link,
     margin-top: var(--spacings-medium);
     display: flex;
 
-    svg {
+    svg,
+    .ui-img-dark {
         display: block;
         flex-shrink: 0;
     }


### PR DESCRIPTION
Med overgang til mer dynamisk bilder som støtter ulike bilder for darkmode osv, så er det enkelte steder hvor det ikke blir hensyntatt i spacing. Dette er et forsøk på å fikse det.

![Screenshot 2021-12-13 at 11 47 04](https://user-images.githubusercontent.com/606374/145798962-b96c02ca-d518-4901-9bb7-0773b517f26d.png)
