### PR TITLE
fix: Replace icon and text for completed purchases

### DIFF
--- a/src/elm/Ui/TicketDetails.elm
+++ b/src/elm/Ui/TicketDetails.elm
@@ -275,15 +275,20 @@ viewActivation ( reservation, status ) =
             ]
 
         icon =
-            activeReservationLoading
+            case status of
+                Captured ->
+                    Icon.checkmark
+
+                NotCaptured ->
+                    activeReservationLoading
 
         captureText =
             case status of
                 Captured ->
-                    "Betaling godkjent. Henter billett..."
+                    "Betaling godkjent. Kjøpet ditt vil straks vises under."
 
                 NotCaptured ->
-                    "Prosesseres... ikke gyldig enda."
+                    "Kjøpet ditt prosesseres... ikke gyldig enda."
 
         spellableOrderId =
             SR.makeSpellable reservation.orderId


### PR DESCRIPTION
Etter fullført kjøp i nettbutikk settes reservasjons-statusen for kjøpet til "Captured", og det vises det en melding på toppen med en spinner og teksten "Betaling godkjent. Henter billett...". Denne forsvinner ikke før bruker laster siden på nytt. 

I og med at det ikke settes ny status her når billetten er ferdig lastet inn i nettbutikken, er forslaget for bedre feedback her et mer passende ikon og en mer beskrivende tekst. Tar gjerne i mot forslag til andre måter å løse dette på, og eventuelt feedback på valgt ikon og tekst.

Før: 
![image](https://user-images.githubusercontent.com/21310942/147262349-7645fdde-cab6-4a8c-be98-7199ee77bf05.png)

Nå: 
![image](https://user-images.githubusercontent.com/21310942/147262466-efa0c6b7-3b8c-4e46-9de7-2eb803b9b6bf.png)
