### PR TITLE
feat: add dynamic travel modes based on org

### DIFF
--- a/orgs/atb.json
+++ b/orgs/atb.json
@@ -5,5 +5,6 @@
     "privacyDeclarationUrl": "https://beta.atb.no/private-policy",
     "englishTranslationsUrl": "https://www.atb.no/ny-nettbutikk/key-words-and-phrases-article17509-2740.html",
     "newWebshopUrl": "https://www.atb.no/vi-oppgraderer/",
-    "travelCardValidPrefix": "1616006"
+    "travelCardValidPrefix": "1616006",
+    "defaultTravelModes": "Buss / trikk"
 }

--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -4,5 +4,6 @@
     "zoneMapUrl": "https://static1.squarespace.com/static/60019c06f8f42f6c20a066eb/t/604f636f8509920229480e08/1615815536923/Sonekart+Nordland.pdf",
     "privacyDeclarationUrl": "https://www.reisnordland.no/personvern-og-cookies",
     "newWebshopUrl": "https://www.reisnordland.no/nettbutikk",
-    "travelCardValidPrefix": ""
+    "travelCardValidPrefix": "",
+    "defaultTravelModes": "Buss / hurtigbåt"
 }

--- a/src/elm/Base.elm
+++ b/src/elm/Base.elm
@@ -17,4 +17,5 @@ type alias AppInfo =
     , englishTranslationsUrl : Maybe String
     , newWebshopUrl : Maybe String
     , travelCardValidPrefix : String
+    , defaultTravelModes : String
     }

--- a/src/elm/Data/Organization.elm
+++ b/src/elm/Data/Organization.elm
@@ -13,6 +13,7 @@ type alias OrganizationConfiguration =
     , englishTranslationsUrl : Maybe String
     , newWebshopUrl : Maybe String
     , travelCardValidPrefix : String
+    , defaultTravelModes : String
     }
 
 
@@ -26,6 +27,7 @@ orgConfDecoder =
         |> DecodeP.optional "englishTranslationsUrl" (Decode.map Just Decode.string) Nothing
         |> DecodeP.optional "newWebshopUrl" (Decode.map Just Decode.string) Nothing
         |> DecodeP.required "travelCardValidPrefix" Decode.string
+        |> DecodeP.required "defaultTravelModes" Decode.string
 
 
 orgIdFromString : String -> OrgId

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -295,6 +295,7 @@ init flags url navKey =
             , englishTranslationsUrl = flags.orgConf.englishTranslationsUrl
             , newWebshopUrl = flags.orgConf.newWebshopUrl
             , travelCardValidPrefix = flags.orgConf.travelCardValidPrefix
+            , defaultTravelModes = flags.orgConf.defaultTravelModes
             }
 
         ( overviewModel, overviewCmd ) =

--- a/src/elm/Page/Shop/Carnet.elm
+++ b/src/elm/Page/Shop/Carnet.elm
@@ -352,7 +352,7 @@ view _ appInfo shared model _ =
                                 [ Common.viewZones model appInfo defaultZone shared.tariffZones SetFromZone SetToZone False ]
                             ]
                         , H.div []
-                            [ Common.viewSummary shared model disableButtons GoToSummary Nothing
+                            [ Common.viewSummary shared model appInfo disableButtons GoToSummary Nothing
                             ]
                         ]
                     ]

--- a/src/elm/Page/Shop/CommonViews.elm
+++ b/src/elm/Page/Shop/CommonViews.elm
@@ -51,8 +51,8 @@ viewUserProfile model onUserSelect userProfile =
             |> Radio.view
 
 
-viewSummary : Shared -> CommonModel a -> Bool -> msg -> Maybe (Html msg) -> Html msg
-viewSummary shared model disableButtons onToSummaryClick maybeInfo =
+viewSummary : Shared -> CommonModel a -> AppInfo -> Bool -> msg -> Maybe (Html msg) -> Html msg
+viewSummary shared model appInfo disableButtons onToSummaryClick maybeInfo =
     let
         error =
             case model.offers of
@@ -83,6 +83,7 @@ viewSummary shared model disableButtons onToSummaryClick maybeInfo =
                             , timeZone = model.timeZone
                             }
                             offers
+                            appInfo
                             shared
 
                 _ ->

--- a/src/elm/Page/Shop/Period.elm
+++ b/src/elm/Page/Shop/Period.elm
@@ -600,6 +600,7 @@ view _ appInfo shared model _ =
                             ]
                         , Common.viewSummary shared
                             model
+                            appInfo
                             disableButtons
                             GoToSummary
                             (Maybe.map Message.warning model.overlapMessage)

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -1,5 +1,6 @@
 module Page.Shop.Summary exposing (Model, Msg, Summary, TravellerData, cardReadWarning, init, makeSummary, subscriptions, update, view)
 
+import Base exposing (AppInfo)
 import Data.PaymentType as PaymentType exposing (PaymentCard(..), PaymentSelection(..), PaymentType(..))
 import Data.RefData exposing (FareProduct, LangString(..), ProductType(..), UserProfile, UserType(..))
 import Data.Ticket exposing (Offer, RecurringPayment, Reservation)
@@ -165,11 +166,11 @@ update msg env model shared =
                             PageUpdater.init { model | recurringPayments = Failed errorMessage }
 
 
-view : Shared -> Model -> Html Msg
-view shared model =
+view : Shared -> Model -> AppInfo -> Html Msg
+view shared model appInfo =
     let
         summary =
-            makeSummary model.query model.offers shared
+            makeSummary model.query model.offers appInfo shared
     in
         H.div []
             [ cardReadWarning
@@ -181,8 +182,8 @@ view shared model =
             ]
 
 
-makeSummary : OffersQuery -> List Offer -> Shared -> Summary
-makeSummary query offers shared =
+makeSummary : OffersQuery -> List Offer -> AppInfo -> Shared -> Summary
+makeSummary query offers appInfo shared =
     let
         productName =
             nameFromFareProduct shared.fareProducts query.productId
@@ -197,8 +198,8 @@ makeSummary query offers shared =
         price =
             totalPrice offers
     in
-        { -- @TODO At some point when expanding to different modes, this should be updated.
-          travelMode = "Buss / trikk"
+        { -- @TODO travelMode should be set dynamically based on ticket conditions.
+          travelMode = appInfo.defaultTravelModes
         , productType = productType
         , product = Maybe.withDefault "Ukjent" productName
         , travellers = humanizeTravellerData travellerData


### PR DESCRIPTION
På oppsummering av billettkjøp i webshop er nå "Buss / trikk" hardkodet inn som reisemåte. 

I og med at det ikke kjører særlig mye trikk i Nordland og Møre og Romsdal foreslår jeg å legge inn en fornuftig verdi for standard reisemåte til hver organisasjon, f.eks. "Buss / hurtigbåt".

Så bør nok diskusjonen etterhvert tas på om reisemåte burde komme fra produktet i skyen, men det rekker nok ikke Nordland fikse før produksjonssetting om noen dager.