### PR TITLE
fix: svg loading from css files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -422,19 +422,8 @@ if (isDevelopment) {
                     use: ['style-loader', 'css-loader']
                 },
                 {
-                    test: /\.(svg|eot|otf|ttf|woff|woff2)$/,
+                    test: /\.(eot|otf|ttf|woff|woff2)$/,
                     use: 'file-loader'
-                },
-                {
-                    test: /\.(jpg|png|gif)$/,
-                    use: [
-                        {
-                            loader: 'url-loader',
-                            options: {
-                                limit: 10000
-                            }
-                        }
-                    ]
                 }
             ]
         }
@@ -468,7 +457,7 @@ if (isDevelopment) {
                     }
                 },
                 {
-                    test: /\.(eot|otf|ttf|woff|woff2|jpe?g|png|gif|svg)$/i,
+                    test: /\.(eot|otf|ttf|woff|woff2)$/i,
                     use: {
                         loader: 'file-loader',
                         options: {


### PR DESCRIPTION
Virker som webpack her setter opp noe proxy-filer for routing som ikke blir håndtert rett. Men etter nærmere ettertanke så tenker jeg at det er vel ingen grunn til å ha url eller file loading på data fra css/scss her. Dette unngår å gjøre noen ekstra kode for håndtering av svgs fra css og fikser feil med ikke lastet bakgrunnsbilde nå i staging og prod.