### PR TITLE
feat: handle cases where there are no customer number set on profile

### DIFF
--- a/src/elm/Environment.elm
+++ b/src/elm/Environment.elm
@@ -25,7 +25,7 @@ type alias Environment =
     , installId : String
     , showValidityWarning : Bool
     , customerId : Maybe String
-    , customerNumber : Int
+    , customerNumber : Maybe Int
     , customerEmail : String
     , token : String
     }

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -279,7 +279,7 @@ init flags url navKey =
             , installId = flags.installId
             , showValidityWarning = flags.showValidityWarning
             , customerId = Nothing
-            , customerNumber = 0
+            , customerNumber = Nothing
             , customerEmail = ""
             , token = ""
             }
@@ -377,7 +377,7 @@ update msg model =
                             model.environment
 
                         newEnvironment =
-                            { oldEnvironment | customerNumber = number }
+                            { oldEnvironment | customerNumber = Just number }
                     in
                         ( { model | environment = newEnvironment }, Cmd.none )
 
@@ -884,7 +884,7 @@ type alias UserData =
     , email : String
     , userId : String
     , customerId : String
-    , customerNumber : Int
+    , customerNumber : Maybe Int
     , provider : FirebaseAuth.Provider
     , stopOnboarding : Bool
     }
@@ -901,7 +901,7 @@ userDataDecoder =
                 Decode.string
             )
         |> DecodeP.required "uid" Decode.string
-        |> DecodeP.required "customerNumber" Decode.int
+        |> DecodeP.optional "customerNumber" (Decode.map Just Decode.int) Nothing
         |> DecodeP.required "provider" FirebaseAuth.providerDecoder
         |> DecodeP.optional "stopOnboarding" Decode.bool False
 

--- a/src/elm/Page/Account.elm
+++ b/src/elm/Page/Account.elm
@@ -690,7 +690,7 @@ viewProfile env model profile =
                     )
             , Ui.Section.viewWithIconWidthPadding
                 [ Ui.Section.viewLabelItem "Kundenummer"
-                    [ H.text <| String.fromInt env.customerNumber
+                    [ H.text <| MaybeUtil.mapWithDefault String.fromInt "Fant ikke kundenummer. Ta kontakt med kundeservice" env.customerNumber
                     ]
                 ]
             , viewEmailAddress model profile

--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -302,7 +302,7 @@ viewAccountInfo env shared _ =
                     "Kundenummer"
                     [ H.p [ A.class "accountInfo__item", A.title "Kundenummer" ]
                         [ Icon.profile
-                        , H.text <| Util.Maybe.mapWithDefault String.fromInt "Fant ikke kundenummer. Ta kontakt med kundeservice" env.customerNumber
+                        , H.text <| Util.Maybe.mapWithDefault String.fromInt "Fant ikke kundenummer. Ta kontakt med kundeservice." env.customerNumber
                         ]
                     ]
                 , B.init "Rediger profil"

--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -302,7 +302,7 @@ viewAccountInfo env shared _ =
                     "Kundenummer"
                     [ H.p [ A.class "accountInfo__item", A.title "Kundenummer" ]
                         [ Icon.profile
-                        , H.text <| String.fromInt env.customerNumber
+                        , H.text <| Util.Maybe.mapWithDefault String.fromInt "Fant ikke kundenummer. Ta kontakt med kundeservice" env.customerNumber
                         ]
                     ]
                 , B.init "Rediger profil"

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -261,7 +261,8 @@ async function fetchAuthInfo(user, stopOnboarding) {
                     } else {
                         app.ports.signedInInfo.send({
                             token: idToken.token,
-                            customerNumber: idToken.claims.customer_number,
+                            customerNumber:
+                                idToken.claims.customer_number || null,
                             email: email,
                             phone: phone,
                             uid: accountId,

--- a/src/static/styles/main.scss
+++ b/src/static/styles/main.scss
@@ -411,6 +411,8 @@ p + p {
     display: flex;
     svg,
     .ui-img-dark {
+        flex-shrink: 0;
+        width: var(--icon-size-normal);
         display: block;
         margin-right: var(--spacings-medium);
     }


### PR DESCRIPTION
Jf. tidligere feature rundt visning av customer number (#469), gjorde jeg på en måte en liten blunder men som egentlig er en fordel: Jeg tok ikke høyde for at customer number ikke kunne eksistere. Dette for at vi egentlig skal kunne ha customer number uansett ved innlogging. Men jeg glemte å ta høyde for tilfeller hvor registrering av bruker har feilet.

Historisk sett har skjedd litt pga ymse årsaker og det har vært vanskelig å fange opp. Det er egentlig ikke noe som skal skje, men det kan skje en gang i jubelåret og da ønsker vi at kunden tar kontakt. Forslaget mitt er en enkel melding som viser det her:

![Screenshot 2022-02-10 at 08 34 04](https://user-images.githubusercontent.com/606374/153359137-cba5be8e-e62c-475e-8573-ef500cfbf5c8.png)


Vi kan velge å gjøre mer ut av det med større varsel osv, men dette er egentlig en edge case (som har vist seg å ha skjedd noen ganger).