### PR TITLE
feat: makes buy travel card url configurable

### DIFF
--- a/orgs/atb.json
+++ b/orgs/atb.json
@@ -7,5 +7,6 @@
     "newWebshopUrl": "https://www.atb.no/vi-oppgraderer/",
     "travelCardValidPrefix": "1616006",
     "supportEmail": "kundeservice@atb.no",
-    "supportUrl": "https://atb.no/kundeservice/"
+    "supportUrl": "https://atb.no/kundeservice/",
+    "orderTravelCardUrl": "https://www.atb.no/bestill-tkort/"
 }

--- a/orgs/nfk.json
+++ b/orgs/nfk.json
@@ -7,5 +7,6 @@
     "englishTranslationsUrl": "https://www.reisnordland.no/nettbutikk-key-words-and-phrases",
     "travelCardValidPrefix": "",
     "supportEmail": "sentrumsterminalen@boreal.no",
-    "supportUrl": "https://www.reisnordland.no/kontakt-oss"
+    "supportUrl": "https://www.reisnordland.no/kontakt-oss",
+    "orderTravelCardUrl": "https://www.reisnordland.no/skjema-bestilling-av-reisekort"
 }

--- a/src/elm/Base.elm
+++ b/src/elm/Base.elm
@@ -19,4 +19,5 @@ type alias AppInfo =
     , travelCardValidPrefix : String
     , supportEmail : String
     , supportUrl : String
+    , orderTravelCardUrl : String
     }

--- a/src/elm/Data/Organization.elm
+++ b/src/elm/Data/Organization.elm
@@ -15,6 +15,7 @@ type alias OrganizationConfiguration =
     , travelCardValidPrefix : String
     , supportEmail : String
     , supportUrl : String
+    , orderTravelCardUrl : String
     }
 
 
@@ -30,6 +31,7 @@ orgConfDecoder =
         |> DecodeP.required "travelCardValidPrefix" Decode.string
         |> DecodeP.required "supportEmail" Decode.string
         |> DecodeP.required "supportUrl" Decode.string
+        |> DecodeP.required "orderTravelCardUrl" Decode.string
 
 
 orgIdFromString : String -> OrgId

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -303,6 +303,7 @@ init flags url navKey =
             , travelCardValidPrefix = flags.orgConf.travelCardValidPrefix
             , supportEmail = flags.orgConf.supportEmail
             , supportUrl = flags.orgConf.supportUrl
+            , orderTravelCardUrl = flags.orgConf.orderTravelCardUrl
             }
 
         ( overviewModel, overviewCmd ) =

--- a/src/elm/Page/Account.elm
+++ b/src/elm/Page/Account.elm
@@ -623,7 +623,7 @@ viewMain env model shared appInfo =
                     [ viewProfile env model profile
                     , viewSignIn model profile
                     , viewRecurringPayments model
-                    , viewTravelCard model profile
+                    , viewTravelCard appInfo model profile
                     , viewPrivacy model shared appInfo
                     ]
 
@@ -874,8 +874,8 @@ fieldInEditMode state actual =
     state == Just actual
 
 
-viewTravelCard : Model -> Profile -> Html Msg
-viewTravelCard model profile =
+viewTravelCard : AppInfo -> Model -> Profile -> Html Msg
+viewTravelCard appInfo model profile =
     let
         onSave =
             Just SaveTravelCard
@@ -967,7 +967,7 @@ viewTravelCard model profile =
                                                     [ H.text "Legg til et t:kort" ]
                                                 , H.text ". Har du ikke t:kort kan du "
                                                 , H.a
-                                                    [ A.href "https://www.atb.no/bestill-tkort/"
+                                                    [ A.href appInfo.orderTravelCardUrl
                                                     , A.target "_blank"
                                                     , A.title "Gå til skjema for å bestille nytt t:kort sendt til deg (åpner ny side)."
                                                     ]


### PR DESCRIPTION
Flytter ut URL til org-conf-filer. Enklere å endre og se hva som kan endres. Gjør det også mulig for andre orgs å overstyre.


## Verifikasjon

- [ ] Fungere som før for Atb. Dvs URL på kjøp t:kort går til https://www.atb.no/bestill-tkort/
- [ ] URL for NFK skal gå til https://www.reisnordland.no/skjema-bestilling-av-reisekort