### PR TITLE
feat: makes ticket type readonly on period if only one ticket

### DIFF
--- a/src/elm/Page/Shop/Period.elm
+++ b/src/elm/Page/Shop/Period.elm
@@ -564,12 +564,17 @@ view _ appInfo shared model _ =
                                 , icon = Icon.duration
                                 , value = summary.duration
                                 , open = model.mainView == Duration
-                                , readonly = False
+                                , readonly = List.length shared.availablePeriodProducts == 1
                                 , onOpenClick = Just (ShowView Duration)
                                 , id = "varighet"
                                 , editTextSuffix = "varighet"
                                 }
-                                [ viewProducts model defaultProduct shared.availablePeriodProducts ]
+                                [ if List.length shared.availablePeriodProducts == 1 then
+                                    Html.Extra.nothing
+
+                                  else
+                                    viewProducts model defaultProduct shared.availablePeriodProducts
+                                ]
                             , Ui.Group.view
                                 { title = "Reisende"
                                 , icon = Icon.bus


### PR DESCRIPTION
Dersom det bare er ett periodeprodukt gir det mening å ikke gi brukeren valg om å endre. Spesielt nyttig i tilfeller hvor man vil feature toggle inn og ut produkter.


# Test

- [ ] Dersom det kun er ett periodeprodukt tilgjengelig (kan toggles via Firebase Store distributionChannel på produkt) skal det ikke kunne velges mellom produkter.
- [ ] Skjermleser skal fungere med å lese opp valgt
- [ ] Standardprodukt skal velges uten problemer.

<img width="672" alt="Screenshot 2022-02-17 at 12 17 20" src="https://user-images.githubusercontent.com/606374/154470680-9ad10033-ca39-4ee3-9fa5-45158619fd76.png">
