### PR TITLE
breaking-change: flag for sca excemption to reserve

### DIFF
--- a/src/elm/Data/Reservation.elm
+++ b/src/elm/Data/Reservation.elm
@@ -1,4 +1,4 @@
-module Data.Reservation exposing (..)
+module Data.Reservation exposing (PaymentStatus(..), Reservation)
 
 import Data.PaymentType exposing (PaymentType)
 
@@ -9,11 +9,17 @@ type alias Reservation =
     , paymentId : Int
     , transactionId : Int
     , url : String
-    , paymentType : PaymentType
-    , paymentStatus : ReservationStatus
+    , paymentStatus : Maybe PaymentStatus
+    , paymentType : Maybe PaymentType
     }
 
 
-type ReservationStatus
-    = Captured
-    | NotCaptured
+type PaymentStatus
+    = AUTHENTICATE
+    | CANCEL
+    | CAPTURE
+    | CREATE
+    | CREDIT
+    | IMPORT
+    | INITIATE
+    | REJECT

--- a/src/elm/Data/Reservation.elm
+++ b/src/elm/Data/Reservation.elm
@@ -1,0 +1,19 @@
+module Data.Reservation exposing (..)
+
+import Data.PaymentType exposing (PaymentType)
+
+
+type alias Reservation =
+    { created : Int
+    , orderId : String
+    , paymentId : Int
+    , transactionId : Int
+    , url : String
+    , paymentType : PaymentType
+    , paymentStatus : ReservationStatus
+    }
+
+
+type ReservationStatus
+    = Captured
+    | NotCaptured

--- a/src/elm/Data/Ticket.elm
+++ b/src/elm/Data/Ticket.elm
@@ -3,6 +3,8 @@ module Data.Ticket exposing
     , Price
     , RecurringPayment
     , Ticket
+    , TicketReservation
+    , TicketReservationStatus(..)
     )
 
 import Data.PaymentType exposing (PaymentType)
@@ -34,6 +36,19 @@ type alias Offer =
     , travellerId : String
     , validTo : String
     , validFrom : String
+    }
+
+
+type TicketReservationStatus
+    = Captured
+    | NotCaptured
+
+
+type alias TicketReservation =
+    { orderId : String
+    , paymentId : Int
+    , transactionId : Int
+    , url : String
     }
 
 

--- a/src/elm/Data/Ticket.elm
+++ b/src/elm/Data/Ticket.elm
@@ -1,10 +1,7 @@
 module Data.Ticket exposing
     ( Offer
-    , PaymentStatus
     , Price
     , RecurringPayment
-    , Reservation
-    , ReservationStatus(..)
     , Ticket
     )
 
@@ -37,26 +34,6 @@ type alias Offer =
     , travellerId : String
     , validTo : String
     , validFrom : String
-    }
-
-
-type ReservationStatus
-    = Captured
-    | NotCaptured
-
-
-type alias Reservation =
-    { orderId : String
-    , paymentId : Int
-    , transactionId : Int
-    , url : String
-    }
-
-
-type alias PaymentStatus =
-    { orderId : String
-    , status : String
-    , paymentType : String
     }
 
 

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -230,23 +230,8 @@ setRouteInternal initialRoute maybeRoute model =
                     Just Route.Home ->
                         TaskUtil.doTask <| OverviewMsg OverviewPage.OnEnterPage
 
-                    Just (Route.Payment maybeReservation) ->
-                        let
-                            noPaymentId =
-                                maybeReservation.paymentId == Nothing
-
-                            isCancelled =
-                                maybeReservation.responseCode
-                                    |> Maybe.map ((==) Route.Cancel)
-                                    |> Maybe.withDefault False
-                        in
-                            if noPaymentId || isCancelled then
-                                Route.modifyUrl model.navKey Route.Home
-
-                            else
-                                Cmd.batch
-                                    [ Route.modifyUrl model.navKey Route.Home
-                                    ]
+                    Just (Route.Payment _) ->
+                        Route.modifyUrl model.navKey Route.Home
 
                     Just _ ->
                         TaskUtil.doTask <| GlobalAction <| GA.SetTitle Nothing

--- a/src/elm/Main.elm
+++ b/src/elm/Main.elm
@@ -239,21 +239,13 @@ setRouteInternal initialRoute maybeRoute model =
                                 maybeReservation.responseCode
                                     |> Maybe.map ((==) Route.Cancel)
                                     |> Maybe.withDefault False
-
-                            reservation =
-                                { transactionId = Maybe.withDefault 1 maybeReservation.transactionId
-                                , paymentId = Maybe.withDefault 1 maybeReservation.paymentId
-                                , orderId = Maybe.withDefault "" maybeReservation.orderId
-                                , url = ""
-                                }
                         in
                             if noPaymentId || isCancelled then
                                 Route.modifyUrl model.navKey Route.Home
 
                             else
                                 Cmd.batch
-                                    [ TaskUtil.doTask <| OverviewMsg <| OverviewPage.AddActiveReservation reservation
-                                    , Route.modifyUrl model.navKey Route.Home
+                                    [ Route.modifyUrl model.navKey Route.Home
                                     ]
 
                     Just _ ->

--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -31,6 +31,7 @@ import Ui.TravelCardText
 import Util.FareContract
 import Util.Maybe
 import Util.PhoneNumber
+import Util.Reservation
 import Util.Status exposing (Status(..))
 
 
@@ -112,7 +113,11 @@ update msg env model shared =
         ReceiveReservations result ->
             case result of
                 Ok reservations ->
-                    PageUpdater.init { model | reservations = reservations }
+                    let
+                        filteredReservations =
+                            Util.Reservation.filterValidReservations model.currentTime reservations
+                    in
+                        PageUpdater.init { model | reservations = filteredReservations }
 
                 Err _ ->
                     PageUpdater.init

--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -2,7 +2,6 @@ module Page.Overview exposing (Model, Msg(..), init, subscriptions, update, view
 
 import Base exposing (AppInfo)
 import Data.FareContract exposing (FareContract, FareContractState(..), TravelRight(..))
-import Data.Ticket exposing (PaymentStatus, Reservation, ReservationStatus(..))
 import Data.Webshop exposing (Inspection, Token)
 import Environment exposing (Environment)
 import Fragment.Icon as Icon
@@ -15,7 +14,6 @@ import Json.Decode as Decode exposing (Decoder)
 import List.Extra
 import Notification
 import PageUpdater exposing (PageUpdater)
-import Process
 import Route exposing (Route)
 import Service.Misc as MiscService exposing (Profile)
 import Service.Ticket as TicketService

--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -358,7 +358,7 @@ viewMain shared model =
 viewPending : Model -> List (Html msg)
 viewPending model =
     model.reservations
-        |> List.map Ui.TicketDetails.viewActivation
+        |> List.map Ui.TicketDetails.viewReservation
 
 
 viewTicketCards : Shared -> List FareContract -> Model -> List (Html Msg)

--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -328,8 +328,11 @@ viewMain shared model =
             model.tickets
                 |> Util.FareContract.filterNotExpiredAtTime model.currentTime
 
+        validReservations =
+            model.reservations
+
         emptyResults =
-            List.isEmpty validTickets
+            List.isEmpty validTickets && List.isEmpty validReservations
     in
         H.div [ A.class "main" ]
             [ case ( emptyResults, model.error ) of
@@ -349,9 +352,8 @@ viewMain shared model =
 
 viewPending : Model -> List (Html msg)
 viewPending model =
-    -- model.reservations
-    --     |> List.map Ui.TicketDetails.viewActivation
-    []
+    model.reservations
+        |> List.map Ui.TicketDetails.viewActivation
 
 
 viewTicketCards : Shared -> List FareContract -> Model -> List (Html Msg)

--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -114,16 +114,12 @@ update msg env model shared =
                 Ok reservations ->
                     PageUpdater.init { model | reservations = reservations }
 
-                Err err ->
-                    let
-                        foo =
-                            Debug.log "err" err
-                    in
-                        PageUpdater.init
-                            { model
-                                | error =
-                                    Just "Fikk ikke hentet billetter. Prøv igjen senere, eller ta kontakt med kundeservice om problemet vedvarer."
-                            }
+                Err _ ->
+                    PageUpdater.init
+                        { model
+                            | error =
+                                Just "Fikk ikke hentet billetter. Prøv igjen senere, eller ta kontakt med kundeservice om problemet vedvarer."
+                        }
 
         ReceiveTokenPayloads result ->
             case result of

--- a/src/elm/Page/Overview.elm
+++ b/src/elm/Page/Overview.elm
@@ -114,12 +114,16 @@ update msg env model shared =
                 Ok reservations ->
                     PageUpdater.init { model | reservations = reservations }
 
-                Err _ ->
-                    PageUpdater.init
-                        { model
-                            | error =
-                                Just "Fikk ikke hentet billetter. Prøv igjen senere, eller ta kontakt med kundeservice om problemet vedvarer."
-                        }
+                Err err ->
+                    let
+                        foo =
+                            Debug.log "err" err
+                    in
+                        PageUpdater.init
+                            { model
+                                | error =
+                                    Just "Fikk ikke hentet billetter. Prøv igjen senere, eller ta kontakt med kundeservice om problemet vedvarer."
+                            }
 
         ReceiveTokenPayloads result ->
             case result of

--- a/src/elm/Page/Shop/Carnet.elm
+++ b/src/elm/Page/Shop/Carnet.elm
@@ -2,7 +2,8 @@ module Page.Shop.Carnet exposing (Model, Msg(..), init, subscriptions, update, v
 
 import Base exposing (AppInfo)
 import Data.RefData exposing (LangString(..), ProductType(..), UserType(..))
-import Data.Ticket exposing (Offer, Reservation)
+import Data.Reservation exposing (Reservation)
+import Data.Ticket exposing (Offer)
 import Environment exposing (Environment)
 import Fragment.Icon as Icon
 import GlobalActions as GA

--- a/src/elm/Page/Shop/Period.elm
+++ b/src/elm/Page/Shop/Period.elm
@@ -3,7 +3,8 @@ module Page.Shop.Period exposing (Model, Msg(..), init, subscriptions, update, v
 import Base exposing (AppInfo)
 import Data.FareContract exposing (FareContract, FareContractState(..))
 import Data.RefData exposing (FareProduct, LangString(..), ProductType(..), UserType(..))
-import Data.Ticket exposing (Offer, Reservation)
+import Data.Reservation exposing (Reservation)
+import Data.Ticket exposing (Offer)
 import Environment exposing (Environment)
 import Fragment.Icon as Icon
 import GlobalActions as GA

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -2,7 +2,8 @@ module Page.Shop.Summary exposing (Model, Msg, Summary, TravellerData, cardReadW
 
 import Data.PaymentType as PaymentType exposing (PaymentCard(..), PaymentSelection(..), PaymentType(..))
 import Data.RefData exposing (FareProduct, LangString(..), ProductType(..), UserProfile, UserType(..))
-import Data.Ticket exposing (Offer, RecurringPayment, Reservation)
+import Data.Reservation exposing (Reservation)
+import Data.Ticket exposing (Offer, RecurringPayment)
 import Environment exposing (Environment)
 import Fragment.Icon as Icon
 import GlobalActions as GA

--- a/src/elm/Page/Shop/Summary.elm
+++ b/src/elm/Page/Shop/Summary.elm
@@ -3,7 +3,7 @@ module Page.Shop.Summary exposing (Model, Msg, Summary, TravellerData, cardReadW
 import Data.PaymentType as PaymentType exposing (PaymentCard(..), PaymentSelection(..), PaymentType(..))
 import Data.RefData exposing (FareProduct, LangString(..), ProductType(..), UserProfile, UserType(..))
 import Data.Reservation exposing (Reservation)
-import Data.Ticket exposing (Offer, RecurringPayment)
+import Data.Ticket exposing (Offer, RecurringPayment, TicketReservation)
 import Environment exposing (Environment)
 import Fragment.Icon as Icon
 import GlobalActions as GA
@@ -36,7 +36,7 @@ import Util.Time as TimeUtil
 
 type Msg
     = BuyOffers
-    | ReceiveBuyOffers (Result Http.Error Reservation)
+    | ReceiveBuyOffers (Result Http.Error TicketReservation)
     | ReceiveRecurringPayments (Result Http.Error (List RecurringPayment))
     | SetPaymentSelection PaymentSelection
     | SetStorePayment Bool

--- a/src/elm/Service/Misc.elm
+++ b/src/elm/Service/Misc.elm
@@ -21,6 +21,7 @@ port module Service.Misc exposing
 
 import Data.FareContract exposing (FareContract, FareContractState(..), TravelRight(..), TravelRightBase, TravelRightCarnet, TravelRightFull, UsedAccess)
 import Data.PaymentType as PaymentType
+import Data.Reservation exposing (Reservation)
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as DecodeP
 import Json.Encode as Encode
@@ -180,6 +181,24 @@ onProfileChange msg =
 saveProfile : Profile -> Cmd msg
 saveProfile =
     encodeProfile >> firestoreWriteProfile
+
+
+{-| Decode a fare cxontract from Firestore.
+-}
+reservationDecoder : Decoder Reservation
+reservationDecoder =
+    Decode.succeed FareContract
+        |> DecodeP.required "created" Decode.int
+        |> DecodeP.required "orderId" Decode.string
+        |> DecodeP.required "paymentId" Decode.int
+        |> DecodeP.required "transactionId" Decode.int
+        |> DecodeP.required "url" Decode.string
+        |> DecodeP.optional "paymentType"
+            (Decode.andThen
+                (List.filterMap PaymentType.fromEntur >> Decode.succeed)
+                (Decode.list Decode.string)
+            )
+            []
 
 
 {-| Decode a fare contract from Firestore.

--- a/src/elm/Service/Misc.elm
+++ b/src/elm/Service/Misc.elm
@@ -188,7 +188,7 @@ saveProfile =
     encodeProfile >> firestoreWriteProfile
 
 
-{-| Decode a fare cxontract from Firestore.
+{-| Decode a reservation from Firestore.
 -}
 reservationDecoder : Decoder Reservation
 reservationDecoder =
@@ -201,8 +201,8 @@ reservationDecoder =
         |> DecodeP.optional "paymentStatus" paymentStatusDecoder Nothing
         |> DecodeP.optional "paymentType"
             (Decode.andThen
-                (PaymentType.fromEntur >> Decode.succeed)
-                Decode.string
+                (PaymentType.fromInt >> Decode.succeed)
+                Decode.int
             )
             Nothing
 

--- a/src/elm/Service/Ticket.elm
+++ b/src/elm/Service/Ticket.elm
@@ -62,7 +62,7 @@ reserve env phoneNumber paymentSelection storePayment offers =
             [ ( "offers", Encode.list encodeOffer offers )
             , encodePaymentSelection paymentSelection
             , ( "store_payment", encodeStorePayment paymentSelection storePayment )
-            , ( "sca_excemption", Encode.bool True )
+            , ( "sca_excemption", Encode.bool (isScaExcemption paymentSelection) )
             , ( "payment_redirect_url", Encode.string (env.localUrl ++ "/payment?transaction_id={transaction_id}&payment_id={payment_id}&order_id={order_id}") )
             ]
                 ++ MaybeUtil.mapWithDefault (\p -> [ ( "phone_number", Encode.string p ) ]) [] vippsPhoneNumber
@@ -299,6 +299,16 @@ encodePaymentSelection paymentSelection =
 
         Recurring id ->
             ( "recurring_payment_id", Encode.int id )
+
+
+isScaExcemption : PaymentSelection -> Bool
+isScaExcemption paymentSelection =
+    case paymentSelection of
+        NonRecurring PaymentType.Vipps ->
+            False
+
+        _ ->
+            True
 
 
 recurringPaymentDecoder : Decoder RecurringPayment

--- a/src/elm/Service/Ticket.elm
+++ b/src/elm/Service/Ticket.elm
@@ -1,6 +1,5 @@
 module Service.Ticket exposing
     ( endRecurringPayment
-    , getPaymentStatus
     , getRecurringPayments
     , receipt
     , reserve
@@ -88,17 +87,6 @@ receipt env emailAddress orderId =
                 ]
     in
         HttpUtil.post env url (Http.jsonBody body) (Http.expectStringResponse (\_ -> Ok ()))
-
-
-getPaymentStatus : Environment -> Int -> Http.Request PaymentStatus
-getPaymentStatus env paymentId =
-    let
-        url =
-            Url.Builder.crossOrigin env.baseUrl
-                [ "ticket", "v1", "payments", String.fromInt paymentId ]
-                []
-    in
-        HttpUtil.get env url (Http.expectJson paymentStatusDecoder)
 
 
 getRecurringPayments : Environment -> Http.Request (List RecurringPayment)

--- a/src/elm/Service/Ticket.elm
+++ b/src/elm/Service/Ticket.elm
@@ -8,12 +8,14 @@ module Service.Ticket exposing
 
 import Data.PaymentType as PaymentType exposing (PaymentCard(..), PaymentSelection(..), PaymentType(..))
 import Data.RefData exposing (UserType(..))
-import Data.Ticket exposing (Offer, PaymentStatus, Price, RecurringPayment, Reservation)
+import Data.Reservation exposing (Reservation)
+import Data.Ticket exposing (Offer, Price, RecurringPayment)
 import Environment exposing (Environment)
 import Http
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as DecodeP
 import Json.Encode as Encode exposing (Value)
+import Service.Misc exposing (reservationDecoder)
 import Url.Builder
 import Util.Http as HttpUtil
 import Util.Maybe as MaybeUtil
@@ -113,14 +115,6 @@ endRecurringPayment env id =
 
 
 -- INTERNAL
-
-
-paymentStatusDecoder : Decoder PaymentStatus
-paymentStatusDecoder =
-    Decode.succeed PaymentStatus
-        |> DecodeP.required "order_id" Decode.string
-        |> DecodeP.required "status" Decode.string
-        |> DecodeP.required "payment_type" Decode.string
 
 
 encodeTraveller : ( UserType, Int ) -> Value
@@ -248,15 +242,6 @@ encodeOffer ( offerId, count ) =
         [ ( "offer_id", Encode.string offerId )
         , ( "count", Encode.int count )
         ]
-
-
-reservationDecoder : Decoder Reservation
-reservationDecoder =
-    Decode.succeed Reservation
-        |> DecodeP.required "order_id" Decode.string
-        |> DecodeP.required "payment_id" Decode.int
-        |> DecodeP.required "transaction_id" Decode.int
-        |> DecodeP.required "url" Decode.string
 
 
 encodePaymentType : PaymentType -> Value

--- a/src/elm/Service/Ticket.elm
+++ b/src/elm/Service/Ticket.elm
@@ -8,14 +8,12 @@ module Service.Ticket exposing
 
 import Data.PaymentType as PaymentType exposing (PaymentCard(..), PaymentSelection(..), PaymentType(..))
 import Data.RefData exposing (UserType(..))
-import Data.Reservation exposing (Reservation)
-import Data.Ticket exposing (Offer, Price, RecurringPayment)
+import Data.Ticket exposing (Offer, Price, RecurringPayment, TicketReservation)
 import Environment exposing (Environment)
 import Http
 import Json.Decode as Decode exposing (Decoder)
 import Json.Decode.Pipeline as DecodeP
 import Json.Encode as Encode exposing (Value)
-import Service.Misc exposing (reservationDecoder)
 import Url.Builder
 import Util.Http as HttpUtil
 import Util.Maybe as MaybeUtil
@@ -48,7 +46,7 @@ search env travelDate product travellers zones =
 
 {-| Reserve offers.
 -}
-reserve : Environment -> Maybe String -> PaymentSelection -> Bool -> List ( String, Int ) -> Http.Request Reservation
+reserve : Environment -> Maybe String -> PaymentSelection -> Bool -> List ( String, Int ) -> Http.Request TicketReservation
 reserve env phoneNumber paymentSelection storePayment offers =
     let
         url =
@@ -242,6 +240,15 @@ encodeOffer ( offerId, count ) =
         [ ( "offer_id", Encode.string offerId )
         , ( "count", Encode.int count )
         ]
+
+
+reservationDecoder : Decoder TicketReservation
+reservationDecoder =
+    Decode.succeed TicketReservation
+        |> DecodeP.required "order_id" Decode.string
+        |> DecodeP.required "payment_id" Decode.int
+        |> DecodeP.required "transaction_id" Decode.int
+        |> DecodeP.required "url" Decode.string
 
 
 encodePaymentType : PaymentType -> Value

--- a/src/elm/Service/Ticket.elm
+++ b/src/elm/Service/Ticket.elm
@@ -62,6 +62,7 @@ reserve env phoneNumber paymentSelection storePayment offers =
             [ ( "offers", Encode.list encodeOffer offers )
             , encodePaymentSelection paymentSelection
             , ( "store_payment", encodeStorePayment paymentSelection storePayment )
+            , ( "sca_excemption", Encode.bool True )
             , ( "payment_redirect_url", Encode.string (env.localUrl ++ "/payment?transaction_id={transaction_id}&payment_id={payment_id}&order_id={order_id}") )
             ]
                 ++ MaybeUtil.mapWithDefault (\p -> [ ( "phone_number", Encode.string p ) ]) [] vippsPhoneNumber

--- a/src/elm/Ui/TicketDetails.elm
+++ b/src/elm/Ui/TicketDetails.elm
@@ -262,8 +262,8 @@ viewActiveAccessText validAccesses =
             String.fromInt num ++ " aktive klipp"
 
 
-viewActivation : ( Reservation, PaymentStatus ) -> Html msg
-viewActivation ( reservation, status ) =
+viewActivation : Reservation -> Html msg
+viewActivation reservation =
     let
         classList =
             [ ( "ui-ticketDetails", True )
@@ -278,8 +278,8 @@ viewActivation ( reservation, status ) =
             activeReservationLoading
 
         captureText =
-            case status of
-                CAPTURE ->
+            case reservation.paymentStatus of
+                Just CAPTURE ->
                     "Betaling godkjent. Henter billett..."
 
                 _ ->

--- a/src/elm/Ui/TicketDetails.elm
+++ b/src/elm/Ui/TicketDetails.elm
@@ -305,7 +305,7 @@ viewActivation reservation =
                             (SR.readAndView spellableOrderId reservation.orderId)
                         , Html.Extra.viewMaybe
                             (\paymentType ->
-                                Ui.LabelItem.viewCompact "Betalt med" [ H.text <| formatPaymentType [ paymentType ] ]
+                                Ui.LabelItem.viewCompact "Betales med" [ H.text <| formatPaymentType [ paymentType ] ]
                             )
                             reservation.paymentType
                         ]

--- a/src/elm/Ui/TicketDetails.elm
+++ b/src/elm/Ui/TicketDetails.elm
@@ -271,7 +271,6 @@ viewActivation reservation =
 
         classListMetadata =
             [ ( "ui-ticketDetails__metaDataitem", True )
-            , ( "ui-ticketDetails__metaDataitem--padded", True )
             ]
 
         icon =
@@ -300,9 +299,16 @@ viewActivation reservation =
                         ]
                     ]
                 , H.div [ A.classList classListMetadata ]
-                    [ Ui.LabelItem.viewCompact
-                        "Ordre-ID"
-                        (SR.readAndView spellableOrderId reservation.orderId)
+                    [ viewHorizontalItem
+                        [ Ui.LabelItem.viewCompact
+                            "Ordre-ID"
+                            (SR.readAndView spellableOrderId reservation.orderId)
+                        , Html.Extra.viewMaybe
+                            (\paymentType ->
+                                Ui.LabelItem.viewCompact "Betalt med" [ H.text <| formatPaymentType [ paymentType ] ]
+                            )
+                            reservation.paymentType
+                        ]
                     ]
                 ]
             ]

--- a/src/elm/Ui/TicketDetails.elm
+++ b/src/elm/Ui/TicketDetails.elm
@@ -3,7 +3,7 @@ module Ui.TicketDetails exposing (view, viewActivation)
 import Data.FareContract exposing (FareContract, TravelRight(..), TravelRightCarnet)
 import Data.PaymentType as PaymentType exposing (PaymentType)
 import Data.RefData exposing (LangString(..))
-import Data.Ticket exposing (Reservation, ReservationStatus(..))
+import Data.Reservation exposing (PaymentStatus(..), Reservation)
 import Dict exposing (Dict)
 import Dict.Extra
 import Fragment.Icon as Icon
@@ -262,7 +262,7 @@ viewActiveAccessText validAccesses =
             String.fromInt num ++ " aktive klipp"
 
 
-viewActivation : ( Reservation, ReservationStatus ) -> Html msg
+viewActivation : ( Reservation, PaymentStatus ) -> Html msg
 viewActivation ( reservation, status ) =
     let
         classList =
@@ -279,10 +279,10 @@ viewActivation ( reservation, status ) =
 
         captureText =
             case status of
-                Captured ->
+                CAPTURE ->
                     "Betaling godkjent. Henter billett..."
 
-                NotCaptured ->
+                _ ->
                     "Prosesseres... ikke gyldig enda."
 
         spellableOrderId =

--- a/src/elm/Ui/TicketDetails.elm
+++ b/src/elm/Ui/TicketDetails.elm
@@ -1,4 +1,4 @@
-module Ui.TicketDetails exposing (view, viewActivation)
+module Ui.TicketDetails exposing (view, viewReservation)
 
 import Data.FareContract exposing (FareContract, TravelRight(..), TravelRightCarnet)
 import Data.PaymentType as PaymentType exposing (PaymentType)
@@ -262,8 +262,8 @@ viewActiveAccessText validAccesses =
             String.fromInt num ++ " aktive klipp"
 
 
-viewActivation : Reservation -> Html msg
-viewActivation reservation =
+viewReservation : Reservation -> Html msg
+viewReservation reservation =
     let
         classList =
             [ ( "ui-ticketDetails", True )

--- a/src/elm/Util/FareContract.elm
+++ b/src/elm/Util/FareContract.elm
@@ -1,4 +1,4 @@
-module Util.FareContract exposing (filterNotExpiredAtTime, filterValidAtTime, hasValidState, isNotExpired, isValid)
+module Util.FareContract exposing (filterNotExpiredAtTime, filterValidAtTime, hasValidState, isNotExpired, isValid, toSortedValidFareContracts)
 
 import Data.FareContract exposing (FareContract, FareContractState(..), TravelRight(..))
 import Time
@@ -27,6 +27,14 @@ filterNotExpiredAtTime timePosix fareContracts =
         |> List.filter (.validTo >> isNotExpired timePosix)
         |> List.filter (hasValidTravelRight timePosix)
         |> List.filter hasValidState
+
+
+toSortedValidFareContracts : Time.Posix -> List FareContract -> List FareContract
+toSortedValidFareContracts timePosix fareContracts =
+    fareContracts
+        |> filterNotExpiredAtTime timePosix
+        |> List.sortBy .created
+        |> List.reverse
 
 
 isNotExpired : Time.Posix -> Int -> Bool

--- a/src/elm/Util/Reservation.elm
+++ b/src/elm/Util/Reservation.elm
@@ -1,5 +1,6 @@
 module Util.Reservation exposing (filterValidReservations, isNotAbortedReservation, isReservationWithinAnHour)
 
+import Data.FareContract exposing (FareContract)
 import Data.Reservation exposing (PaymentStatus(..), Reservation)
 import Time
 
@@ -26,9 +27,19 @@ isReservationWithinAnHour now reservation =
         anHourAfterReservation >= nowMs
 
 
-filterValidReservations : Time.Posix -> List Reservation -> List Reservation
-filterValidReservations currentTime reservations =
+isNotInFareContracts : List FareContract -> Reservation -> Bool
+isNotInFareContracts fareContracts reservation =
+    let
+        orderIds =
+            List.map .orderId fareContracts
+    in
+        not <| List.member reservation.orderId orderIds
+
+
+filterValidReservations : Time.Posix -> List FareContract -> List Reservation -> List Reservation
+filterValidReservations currentTime fareContracts reservations =
     reservations
         |> List.filter (.paymentStatus >> (/=) Nothing)
         |> List.filter isNotAbortedReservation
         |> List.filter (isReservationWithinAnHour currentTime)
+        |> List.filter (isNotInFareContracts fareContracts)

--- a/src/elm/Util/Reservation.elm
+++ b/src/elm/Util/Reservation.elm
@@ -1,0 +1,34 @@
+module Util.Reservation exposing (filterValidReservations, isNotAbortedReservation, isReservationWithinAnHour)
+
+import Data.Reservation exposing (PaymentStatus(..), Reservation)
+import Time
+
+
+isNotAbortedReservation : Reservation -> Bool
+isNotAbortedReservation reservation =
+    case reservation.paymentStatus of
+        Nothing ->
+            False
+
+        Just paymentStatus ->
+            not <| List.member paymentStatus [ CANCEL, CREDIT, REJECT ]
+
+
+isReservationWithinAnHour : Time.Posix -> Reservation -> Bool
+isReservationWithinAnHour now reservation =
+    let
+        anHourAfterReservation =
+            reservation.created + (60 * 60 * 1000)
+
+        nowMs =
+            Time.posixToMillis now
+    in
+        anHourAfterReservation >= nowMs
+
+
+filterValidReservations : Time.Posix -> List Reservation -> List Reservation
+filterValidReservations currentTime reservations =
+    reservations
+        |> List.filter (.paymentStatus >> (/=) Nothing)
+        |> List.filter isNotAbortedReservation
+        |> List.filter (isReservationWithinAnHour currentTime)


### PR DESCRIPTION
breaking-change: Requires update-reservation Cloud Function, new ticketing service.

- Updates Webshop to send in sca_excemption when not Vipps payment
- Changes to use reservation stored in Firebase Store instead of locally in memory. Currently not taking full advantage of that except it is persistent between instances (app/webshop) and persistent when refreshing site. A good follow-up of this task is to better handle cancellation/timeouts etc and utilize reservation persistence more.
- Adds payment type to the reservation as this has been an expressed wish previously but not available in the data before.

---
<img width="679" alt="Screenshot 2022-02-24 at 13 36 19" src="https://user-images.githubusercontent.com/606374/155525401-92531082-ebcb-4ac4-b8f6-39869ce9875a.png">
<img width="653" alt="Screenshot 2022-02-24 at 13 36 16" src="https://user-images.githubusercontent.com/606374/155525406-98239cb7-894a-40bb-8dd6-12ba8a7fa002.png">
<img width="1778" alt="Screenshot 2022-02-24 at 13 35 50" src="https://user-images.githubusercontent.com/606374/155525409-2961183a-0dfe-453e-9f52-f0da2a585e22.png">

