### PR TITLE
fix: e2e - make 24hr default ticket for tests to pass

### DIFF
--- a/e2e-tests/cypress/integration/pageobjects/buyticket.pageobject.js
+++ b/e2e-tests/cypress/integration/pageobjects/buyticket.pageobject.js
@@ -41,6 +41,7 @@ export const summary = {
 
 export const options = {
     value: elem => cy.wrap(elem).find(".ui-labelItem"),
+    choices: elem => cy.wrap(elem).find('.ui-input-radioGroup').find('.ui-group__item'),
     areVisible: (elem, bool) => {
         if (bool){
             cy.wrap(elem).find(".ui-group__content").should("have.class", "ui-group__content--open")

--- a/e2e-tests/cypress/integration/tests/periodtickets.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/periodtickets.e2e_spec.js
@@ -4,7 +4,8 @@ import {
     options,
     products,
     summary,
-    traveller, travelTime,
+    traveller,
+    travelTime,
     zone
 } from '../pageobjects/buyticket.pageobject';
 import { myprofile } from '../pageobjects/myprofile.pageobject';
@@ -13,369 +14,457 @@ describe('period ticket purchase', () => {
     beforeEach(function () {
         cy.visitMainAsAuthorized();
 
-        cy.intercept("**/ticket/v1/search/zones").as("zones")
+        cy.intercept('**/ticket/v1/search/zones').as('zones');
         menu.buyPeriodTicket().click();
-        cy.wait("@zones")
+        cy.wait('@zones');
         verify.verifyHeader('h2', 'Kjøp ny periodebillett');
     });
 
     it('should display default ticket parameters', () => {
-        const defaultPeriodProduct = '24-timersbillett'
-        const defaultPeriodProductPrice = '126,00'
-        const defaultPeriodProductMva = '15,12'
+        const defaultPeriodProduct = '24-timersbillett';
+        const defaultPeriodProductPrice = '126,00';
+        const defaultPeriodProductMva = '15,12';
 
         //Type
-        newTicket.travelType().should("contain", "Buss og trikk")
+        newTicket.travelType().should('contain', 'Buss og trikk');
 
         //Product
-        newTicket.productsSection().then($product => {
-            options.areVisible($product, true)
-            options.value($product).should("contain", defaultPeriodProduct)
-        })
+        newTicket.productsSection().then(($product) => {
+            options.areVisible($product, true);
+            options.value($product).should('contain', defaultPeriodProduct);
+        });
 
         //Traveller
-        newTicket.travellerSection().then($traveller => {
-            options.areVisible($traveller, false)
-            options.value($traveller).should("contain", "1 Voksen")
-        })
+        newTicket.travellerSection().then(($traveller) => {
+            options.areVisible($traveller, false);
+            options.value($traveller).should('contain', '1 Voksen');
+        });
 
         //Travel time
-        newTicket.travelTimeSection().then($time => {
-            options.areVisible($time, false)
-            options.value($time).should("contain", "Kjøpstidspunkt")
-        })
+        newTicket.travelTimeSection().then(($time) => {
+            options.areVisible($time, false);
+            options.value($time).should('contain', 'Kjøpstidspunkt');
+        });
 
         //Zones
-        newTicket.departureZoneSection().should("be.visible")
-        zone.departureZone().should("have.value", "ATB:TariffZone:1")
-        zone.departureZoneTariff("ATB:TariffZone:1").should("have.text", "A")
-        newTicket.arrivalZoneSection().should("be.visible")
-        zone.arrivalZone().should("have.value", "ATB:TariffZone:1")
-        zone.arrivalZoneTariff("ATB:TariffZone:1").should("have.text", "A")
+        newTicket.departureZoneSection().should('be.visible');
+        zone.departureZone().should('have.value', 'ATB:TariffZone:1');
+        zone.departureZoneTariff('ATB:TariffZone:1').should('have.text', 'A');
+        newTicket.arrivalZoneSection().should('be.visible');
+        zone.arrivalZone().should('have.value', 'ATB:TariffZone:1');
+        zone.arrivalZoneTariff('ATB:TariffZone:1').should('have.text', 'A');
 
         //Price
-        newTicket.price()
-            .should("contain", defaultPeriodProductPrice)
-            .and("contain", "kr")
-        newTicket.mva()
-            .should("contain", defaultPeriodProductMva)
-    })
+        newTicket
+            .price()
+            .should('contain', defaultPeriodProductPrice)
+            .and('contain', 'kr');
+        newTicket.mva().should('contain', defaultPeriodProductMva);
+    });
+
+    it('should display all available products', () => {
+        const availableProducts = [
+            '24-timersbillett',
+            '7-dagersbillett',
+            '30-dagersbillett',
+            '60-dagersbillett',
+            '90-dagersbillett',
+            '180-dagersbillett'
+        ];
+
+        // Check number of and specific products are available
+        newTicket.productsSection().then(($product) => {
+            options.areVisible($product, true);
+            options
+                .choices($product)
+                .should('have.length', availableProducts.length);
+            availableProducts.forEach((prod) =>
+                options.choices($product).should('contain', prod)
+            );
+        });
+    });
 
     it('summary should be enabled for existing travel card', () => {
-        newTicket.infoText().should("not.contain", "Legg til et t:kort før kjøp av billett")
-        newTicket.goToSummaryButton().should("not.have.class", "ui-button--disabled")
-        newTicket.goToSummary()
+        newTicket
+            .infoText()
+            .should('not.contain', 'Legg til et t:kort før kjøp av billett');
+        newTicket
+            .goToSummaryButton()
+            .should('not.have.class', 'ui-button--disabled');
+        newTicket.goToSummary();
         verify.verifyHeader('h2', 'Oppsummering');
-    })
+    });
 
     it('should include all payment options', () => {
-        newTicket.goToSummary()
+        newTicket.goToSummary();
         verify.verifyHeader('h2', 'Oppsummering');
 
-        summary.paymentOption("vipps").click()
-        summary.paymentOptionLabel("vipps").should("contain", "Vipps")
+        summary.paymentOption('vipps').click();
+        summary.paymentOptionLabel('vipps').should('contain', 'Vipps');
 
-        summary.paymentOption("visa").click()
-        summary.paymentOptionLabel("visa").should("contain", "Visa")
+        summary.paymentOption('visa').click();
+        summary.paymentOptionLabel('visa').should('contain', 'Visa');
 
-        summary.paymentOption("mastercard").click()
-        summary.paymentOptionLabel("mastercard").should("contain", "MasterCard")
-    })
+        summary.paymentOption('mastercard').click();
+        summary
+            .paymentOptionLabel('mastercard')
+            .should('contain', 'MasterCard');
+    });
 
     it('stored payment cards should be available as payment method', () => {
-        newTicket.goToSummary()
+        newTicket.goToSummary();
         verify.verifyHeader('h2', 'Oppsummering');
 
         //Pre
-        summary.paymentOption("vipps").click()
-        summary.payButton().should('contain', 'Gå til betaling')
+        summary.paymentOption('vipps').click();
+        summary.payButton().should('contain', 'Gå til betaling');
 
         //Verify
-        summary.storedPaymentOption("Visa").click()
-        summary.storedPaymentOptionLabel("Visa").should("contain", "Visa, **** 0004")
-        summary.storedPaymentOptionExpiry("Visa").should("contain", "Utløpsdato 08/24")
-        summary.storedPaymentOptionIcon("Visa").should("have.attr", "src", "/assets/mono/ticketing/Visa.svg")
-        summary.payButton().should('contain', 'Betal nå')
+        summary.storedPaymentOption('Visa').click();
+        summary
+            .storedPaymentOptionLabel('Visa')
+            .should('contain', 'Visa, **** 0004');
+        summary
+            .storedPaymentOptionExpiry('Visa')
+            .should('contain', 'Utløpsdato 08/24');
+        summary
+            .storedPaymentOptionIcon('Visa')
+            .should('have.attr', 'src', '/assets/mono/ticketing/Visa.svg');
+        summary.payButton().should('contain', 'Betal nå');
 
-        summary.storedPaymentOption("MasterCard").click()
-        summary.storedPaymentOptionLabel("MasterCard").should("contain", "MasterCard, **** 0000")
-        summary.storedPaymentOptionExpiry("MasterCard").should("contain", "Utløpsdato 06/24")
-        summary.storedPaymentOptionIcon("MasterCard").should("have.attr", "src", "/assets/mono/ticketing/MasterCard.svg")
-        summary.payButton().should('contain', 'Betal nå')
-    })
+        summary.storedPaymentOption('MasterCard').click();
+        summary
+            .storedPaymentOptionLabel('MasterCard')
+            .should('contain', 'MasterCard, **** 0000');
+        summary
+            .storedPaymentOptionExpiry('MasterCard')
+            .should('contain', 'Utløpsdato 06/24');
+        summary
+            .storedPaymentOptionIcon('MasterCard')
+            .should(
+                'have.attr',
+                'src',
+                '/assets/mono/ticketing/MasterCard.svg'
+            );
+        summary.payButton().should('contain', 'Betal nå');
+    });
 
     it('new card should be able to save', () => {
-        newTicket.goToSummary()
+        newTicket.goToSummary();
         verify.verifyHeader('h2', 'Oppsummering');
 
         //stored payment is default checked
-        summary.paymentOption("vipps").should("not.be.checked")
-        summary.paymentOption("vipps").click()
-        summary.storePayment().should("not.exist")
-        summary.storePaymentLabel().should("not.exist")
+        summary.paymentOption('vipps').should('not.be.checked');
+        summary.paymentOption('vipps').click();
+        summary.storePayment().should('not.exist');
+        summary.storePaymentLabel().should('not.exist');
 
-        summary.paymentOption("visa").click()
-        summary.storePaymentConfirm().should("be.visible").and("not.be.checked")
-        summary.storePaymentLabel().should("be.visible").and("contain", "Lagre betalingskort")
+        summary.paymentOption('visa').click();
+        summary
+            .storePaymentConfirm()
+            .should('be.visible')
+            .and('not.be.checked');
+        summary
+            .storePaymentLabel()
+            .should('be.visible')
+            .and('contain', 'Lagre betalingskort');
 
-        summary.paymentOption("visa").click()
-        summary.storePaymentConfirm().should("be.visible").and("not.be.checked")
-        summary.storePaymentLabel().should("be.visible").and("contain", "Lagre betalingskort")
-    })
+        summary.paymentOption('visa').click();
+        summary
+            .storePaymentConfirm()
+            .should('be.visible')
+            .and('not.be.checked');
+        summary
+            .storePaymentLabel()
+            .should('be.visible')
+            .and('contain', 'Lagre betalingskort');
+    });
 
     it('summary should show default ticket parameters', () => {
-        const defaultPeriodProduct = '24-timersbillett'
-        const defaultPeriodProductPrice = '126,00'
-        const defaultPeriodProductValidity = 1
+        const defaultPeriodProduct = '24-timersbillett';
+        const defaultPeriodProductPrice = '126,00';
+        const defaultPeriodProductValidity = 1;
 
-        newTicket.goToSummary()
+        newTicket.goToSummary();
 
         //Verify defaults
-        summary.ticketDetails("Billettype").should("contain", "Periodebillett")
-        summary.ticketDetails("Reisetype").should("contain", "Buss / trikk")
-        summary.ticketDetails("Periode").should("contain", defaultPeriodProduct)
-        summary.ticketDetails("Reisende").should("contain", "1 Voksen")
-        summary.ticketDetails("Sone").should("contain", "Reise i 1 sone (A)")
-        summary.ticketDetails("Gyldig fra").should("contain", "Kjøpstidspunkt")
-        summary.ticketDetails("Gyldig til").should("contain", getFutureDate(defaultPeriodProductValidity))
-        summary.price().should("contain", defaultPeriodProductPrice)
-    })
+        summary.ticketDetails('Billettype').should('contain', 'Periodebillett');
+        summary.ticketDetails('Reisetype').should('contain', 'Buss / trikk');
+        summary
+            .ticketDetails('Periode')
+            .should('contain', defaultPeriodProduct);
+        summary.ticketDetails('Reisende').should('contain', '1 Voksen');
+        summary.ticketDetails('Sone').should('contain', 'Reise i 1 sone (A)');
+        summary.ticketDetails('Gyldig fra').should('contain', 'Kjøpstidspunkt');
+        summary
+            .ticketDetails('Gyldig til')
+            .should('contain', getFutureDate(defaultPeriodProductValidity));
+        summary.price().should('contain', defaultPeriodProductPrice);
+    });
 
     it('valid to date in summary should reflect the product', () => {
         // 30
-        products.set("30-dagersbillett")
-        newTicket.goToSummary()
-        summary.ticketDetails("Periode").should("contain", "30-dagersbillett")
-        summary.ticketDetails("Gyldig til").should("contain", getFutureDate(30))
+        products.set('30-dagersbillett');
+        newTicket.goToSummary();
+        summary.ticketDetails('Periode').should('contain', '30-dagersbillett');
+        summary
+            .ticketDetails('Gyldig til')
+            .should('contain', getFutureDate(30));
 
         // 180
-        summary.back()
-        products.set("180-dagersbillett")
-        cy.wait("@zones")
-        newTicket.goToSummary()
-        summary.ticketDetails("Periode").should("contain", "180-dagersbillett")
-        summary.ticketDetails("Gyldig til").should("contain", getFutureDate(180))
+        summary.back();
+        products.set('180-dagersbillett');
+        cy.wait('@zones');
+        newTicket.goToSummary();
+        summary.ticketDetails('Periode').should('contain', '180-dagersbillett');
+        summary
+            .ticketDetails('Gyldig til')
+            .should('contain', getFutureDate(180));
 
         // 7
-        summary.back()
-        products.set("7-dagersbillett")
-        cy.wait("@zones")
-        newTicket.goToSummary()
-        summary.ticketDetails("Periode").should("contain", "7-dagersbillett")
-        summary.ticketDetails("Gyldig til").should("contain", getFutureDate(7))
-    })
+        summary.back();
+        products.set('7-dagersbillett');
+        cy.wait('@zones');
+        newTicket.goToSummary();
+        summary.ticketDetails('Periode').should('contain', '7-dagersbillett');
+        summary.ticketDetails('Gyldig til').should('contain', getFutureDate(7));
+    });
 
     it('leaving the summary should remember changed ticket parameters', () => {
-        const trav = 'Barn'
-        const prod = '7-dagersbillett'
+        const trav = 'Barn';
+        const prod = '7-dagersbillett';
 
         //Set non-default values
-        products.set(prod)
-        traveller.showOptions()
-        traveller.set(trav)
+        products.set(prod);
+        traveller.showOptions();
+        traveller.set(trav);
 
         //Go to summary and back
-        newTicket.goToSummary()
+        newTicket.goToSummary();
         verify.verifyHeader('h2', 'Oppsummering');
-        summary.back()
+        summary.back();
 
         //Verify previously set values
         //Product
-        newTicket.productsSection().then($product => {
-            options.value($product).should("contain", prod)
-        })
+        newTicket.productsSection().then(($product) => {
+            options.value($product).should('contain', prod);
+        });
 
         //Traveller
-        newTicket.travellerSection().then($traveller => {
-            options.value($traveller).should("contain", "1 " + trav)
-        })
-    })
+        newTicket.travellerSection().then(($traveller) => {
+            options.value($traveller).should('contain', '1 ' + trav);
+        });
+    });
 
     it('changing ticket product should update the offer and summary', () => {
-        let currentOffer = 890
-        const prod = '7-dagersbillett'
+        let currentOffer = 890;
+        const prod = '7-dagersbillett';
 
         //Change
-        products.set(prod)
-        cy.wait("@zones")
+        products.set(prod);
+        cy.wait('@zones');
 
         //Verify
-        newTicket.price().then($price => {
-            let price = parseInt($price.text().replace(".", "").split(",")[0])
-            expect(price).to.not.eq(currentOffer)
-            expect(price).to.be.lt(currentOffer)
-            currentOffer = price
-        })
-        newTicket.goToSummary()
-        summary.price().then($price => {
-            let price = parseInt($price.text().replace(".", "").split(",")[0])
-            expect(price).to.be.eq(currentOffer)
-        })
-        summary.ticketDetails("Periode").should("contain", prod)
-        summary.back()
-        newTicket.price().then($price => {
-            let price = parseInt($price.text().replace(".", "").split(",")[0])
-            expect(price).to.be.eq(currentOffer)
-        })
-    })
+        newTicket.price().then(($price) => {
+            let price = parseInt($price.text().replace('.', '').split(',')[0]);
+            expect(price).to.not.eq(currentOffer);
+            expect(price).to.be.lt(currentOffer);
+            currentOffer = price;
+        });
+        newTicket.goToSummary();
+        summary.price().then(($price) => {
+            let price = parseInt($price.text().replace('.', '').split(',')[0]);
+            expect(price).to.be.eq(currentOffer);
+        });
+        summary.ticketDetails('Periode').should('contain', prod);
+        summary.back();
+        newTicket.price().then(($price) => {
+            let price = parseInt($price.text().replace('.', '').split(',')[0]);
+            expect(price).to.be.eq(currentOffer);
+        });
+    });
 
     it('changing traveller should update the offer and summary', () => {
-        let currentOffer = 890
-        const trav = 'Barn'
+        let currentOffer = 890;
+        const trav = 'Barn';
 
         //Change
-        traveller.showOptions()
-        traveller.set(trav)
-        cy.wait("@zones")
+        traveller.showOptions();
+        traveller.set(trav);
+        cy.wait('@zones');
 
         //Verify
-        newTicket.price().then($price => {
-            let price = parseInt($price.text().replace(".", "").split(",")[0])
-            expect(price).to.not.eq(currentOffer)
-            expect(price).to.be.lt(currentOffer)
-            currentOffer = price
-        })
-        newTicket.goToSummary()
-        summary.price().then($price => {
-            let price = parseInt($price.text().replace(".", "").split(",")[0])
-            expect(price).to.be.eq(currentOffer)
-        })
-        summary.ticketDetails("Reisende").should("contain", "1 " + trav)
-        summary.back()
-        newTicket.price().then($price => {
-            let price = parseInt($price.text().replace(".", "").split(",")[0])
-            expect(price).to.be.eq(currentOffer)
-        })
-    })
+        newTicket.price().then(($price) => {
+            let price = parseInt($price.text().replace('.', '').split(',')[0]);
+            expect(price).to.not.eq(currentOffer);
+            expect(price).to.be.lt(currentOffer);
+            currentOffer = price;
+        });
+        newTicket.goToSummary();
+        summary.price().then(($price) => {
+            let price = parseInt($price.text().replace('.', '').split(',')[0]);
+            expect(price).to.be.eq(currentOffer);
+        });
+        summary.ticketDetails('Reisende').should('contain', '1 ' + trav);
+        summary.back();
+        newTicket.price().then(($price) => {
+            let price = parseInt($price.text().replace('.', '').split(',')[0]);
+            expect(price).to.be.eq(currentOffer);
+        });
+    });
 
     it('changing zones should update the offer and summary', () => {
-        let currentOffer = 890
-        const periodProd = '30-dagersbillett'
-        const arrZone = 'B1'
+        let currentOffer = 890;
+        const periodProd = '30-dagersbillett';
+        const arrZone = 'B1';
 
         //Init change
-        products.set(periodProd)
-        cy.wait("@zones")
+        products.set(periodProd);
+        cy.wait('@zones');
 
         //Change
-        zone.arrivalZone().select(arrZone)
-        cy.wait("@zones")
+        zone.arrivalZone().select(arrZone);
+        cy.wait('@zones');
 
         //Verify
-        newTicket.price().then($price => {
-            let price = parseInt($price.text().replace(".", "").split(",")[0])
-            expect(price).to.not.eq(currentOffer)
-            expect(price).to.be.gt(currentOffer)
-            currentOffer = price
-        })
-        newTicket.goToSummary()
-        summary.price().then($price => {
-            let price = parseInt($price.text().replace(".", "").split(",")[0])
-            expect(price).to.be.eq(currentOffer)
-        })
-        summary.ticketDetails("Sone").should("contain", "Reise fra sone A til sone " + arrZone)
-        summary.back()
-        newTicket.price().then($price => {
-            let price = parseInt($price.text().replace(".", "").split(",")[0])
-            expect(price).to.be.eq(currentOffer)
-        })
-    })
+        newTicket.price().then(($price) => {
+            let price = parseInt($price.text().replace('.', '').split(',')[0]);
+            expect(price).to.not.eq(currentOffer);
+            expect(price).to.be.gt(currentOffer);
+            currentOffer = price;
+        });
+        newTicket.goToSummary();
+        summary.price().then(($price) => {
+            let price = parseInt($price.text().replace('.', '').split(',')[0]);
+            expect(price).to.be.eq(currentOffer);
+        });
+        summary
+            .ticketDetails('Sone')
+            .should('contain', 'Reise fra sone A til sone ' + arrZone);
+        summary.back();
+        newTicket.price().then(($price) => {
+            let price = parseInt($price.text().replace('.', '').split(',')[0]);
+            expect(price).to.be.eq(currentOffer);
+        });
+    });
 
     it('changing time to travel should not update the offer nor the summary', () => {
-        let currentOffer = ''
+        let currentOffer = '';
 
         //Pre
-        newTicket.price().then($price => {
-            currentOffer = $price.text()
-        })
+        newTicket.price().then(($price) => {
+            currentOffer = $price.text();
+        });
 
         //Change
-        travelTime.showOptions()
-        travelTime.inFuture().click()
-        cy.wait("@zones")
+        travelTime.showOptions();
+        travelTime.inFuture().click();
+        cy.wait('@zones');
 
         //Verify
-        newTicket.price().then($price => {
-            expect($price.text()).to.eq(currentOffer)
-        })
-        newTicket.goToSummary()
-        summary.price().then($price => {
-            expect($price.text()).to.eq(currentOffer)
-        })
-        summary.ticketDetails("Gyldig fra").should("not.contain", "Kjøpstidspunkt")
-        summary.ticketDetails("Gyldig fra").should("contain", getFutureDate(0))
-        summary.back()
-        newTicket.price().then($price => {
-            expect($price.text()).to.eq(currentOffer)
-        })
-    })
+        newTicket.price().then(($price) => {
+            expect($price.text()).to.eq(currentOffer);
+        });
+        newTicket.goToSummary();
+        summary.price().then(($price) => {
+            expect($price.text()).to.eq(currentOffer);
+        });
+        summary
+            .ticketDetails('Gyldig fra')
+            .should('not.contain', 'Kjøpstidspunkt');
+        summary.ticketDetails('Gyldig fra').should('contain', getFutureDate(0));
+        summary.back();
+        newTicket.price().then(($price) => {
+            expect($price.text()).to.eq(currentOffer);
+        });
+    });
 
     //Existing future ticket is starting at mid-day
     it('should show warning for overlapping tickets', () => {
-        const validFrom = Cypress.env('futureTicketStartDateEN')
+        const validFrom = Cypress.env('futureTicketStartDateEN');
 
         //Change date to Cypress.env.futureTicketStartX
-        travelTime.showOptions()
-        travelTime.inFuture().click()
-        cy.wait("@zones")
+        travelTime.showOptions();
+        travelTime.inFuture().click();
+        cy.wait('@zones');
 
-        travelTime.date().type(validFrom)
-        travelTime.time().type("23:00")
+        travelTime.date().type(validFrom);
+        travelTime.time().type('23:00');
 
-        newTicket.warning()
-            .should("contain", "Du har allerede en billett i dette tidsrommet")
-    })
+        newTicket
+            .warning()
+            .should('contain', 'Du har allerede en billett i dette tidsrommet');
+    });
 
     it('should validate time to start', () => {
-        travelTime.showOptions()
-        travelTime.inFuture().click()
-        cy.wait("@zones")
+        travelTime.showOptions();
+        travelTime.inFuture().click();
+        cy.wait('@zones');
 
         //Back in time - hours
-        travelTime.time().type("00:00")
-        travelTime.validityError()
-            .should("contain", "Starttidspunkt kan ikke være før nåværende tid og dato")
+        travelTime.time().type('00:00');
+        travelTime
+            .validityError()
+            .should(
+                'contain',
+                'Starttidspunkt kan ikke være før nåværende tid og dato'
+            );
 
         //Back in time - days
-        travelTime.time().type("23:59")
-        travelTime.validityError()
-            .should("not.exist")
+        travelTime.time().type('23:59');
+        travelTime.validityError().should('not.exist');
 
-        travelTime.date().type(getFutureDateInInputFormat(-1))
-        travelTime.validityError()
-            .should("contain", "Starttidspunkt kan ikke være før nåværende tid og dato")
+        travelTime.date().type(getFutureDateInInputFormat(-1));
+        travelTime
+            .validityError()
+            .should(
+                'contain',
+                'Starttidspunkt kan ikke være før nåværende tid og dato'
+            );
 
         //90+ days forward
-        travelTime.date().type(getFutureDateInInputFormat(91))
-        travelTime.validityError()
-            .should("contain", "Starttidspunkt kan ikke være mer enn 90 dager fram i tid")
-    })
-})
+        travelTime.date().type(getFutureDateInInputFormat(91));
+        travelTime
+            .validityError()
+            .should(
+                'contain',
+                'Starttidspunkt kan ikke være mer enn 90 dager fram i tid'
+            );
+    });
+});
 
-function getFutureDate(incrDays){
+function getFutureDate(incrDays) {
     let myDate = new Date();
     myDate.setDate(myDate.getDate() + incrDays);
 
     let dd = myDate.getDate();
-    let mm = myDate.getMonth()+1;
+    let mm = myDate.getMonth() + 1;
     let yyyy = myDate.getFullYear();
 
-    if(dd<10){dd='0'+dd}
-    if(mm<10){mm='0'+mm}
+    if (dd < 10) {
+        dd = '0' + dd;
+    }
+    if (mm < 10) {
+        mm = '0' + mm;
+    }
 
-    return dd+'.'+mm+'.'+yyyy
+    return dd + '.' + mm + '.' + yyyy;
 }
 
-function getFutureDateInInputFormat(incrDays){
+function getFutureDateInInputFormat(incrDays) {
     let myDate = new Date();
     myDate.setDate(myDate.getDate() + incrDays);
 
     let dd = myDate.getDate();
-    let mm = myDate.getMonth()+1;
+    let mm = myDate.getMonth() + 1;
     let yyyy = myDate.getFullYear();
 
-    if(dd<10){dd='0'+dd}
-    if(mm<10){mm='0'+mm}
+    if (dd < 10) {
+        dd = '0' + dd;
+    }
+    if (mm < 10) {
+        mm = '0' + mm;
+    }
 
-    return yyyy +'-' + mm + '-' + dd
+    return yyyy + '-' + mm + '-' + dd;
 }

--- a/e2e-tests/cypress/integration/tests/periodtickets.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/periodtickets.e2e_spec.js
@@ -20,13 +20,17 @@ describe('period ticket purchase', () => {
     });
 
     it('should display default ticket parameters', () => {
+        const defaultPeriodProduct = '24-timersbillett'
+        const defaultPeriodProductPrice = '126,00'
+        const defaultPeriodProductMva = '15,12'
+
         //Type
         newTicket.travelType().should("contain", "Buss og trikk")
 
         //Product
         newTicket.productsSection().then($product => {
             options.areVisible($product, true)
-            options.value($product).should("contain", "30-dagersbillett")
+            options.value($product).should("contain", defaultPeriodProduct)
         })
 
         //Traveller
@@ -51,10 +55,10 @@ describe('period ticket purchase', () => {
 
         //Price
         newTicket.price()
-            .should("contain", "890,00")
+            .should("contain", defaultPeriodProductPrice)
             .and("contain", "kr")
         newTicket.mva()
-            .should("contain", "106,80")
+            .should("contain", defaultPeriodProductMva)
     })
 
     it('summary should be enabled for existing travel card', () => {
@@ -120,17 +124,21 @@ describe('period ticket purchase', () => {
     })
 
     it('summary should show default ticket parameters', () => {
+        const defaultPeriodProduct = '24-timersbillett'
+        const defaultPeriodProductPrice = '126,00'
+        const defaultPeriodProductValidity = 1
+
         newTicket.goToSummary()
 
         //Verify defaults
         summary.ticketDetails("Billettype").should("contain", "Periodebillett")
         summary.ticketDetails("Reisetype").should("contain", "Buss / trikk")
-        summary.ticketDetails("Periode").should("contain", "30-dagersbillett")
+        summary.ticketDetails("Periode").should("contain", defaultPeriodProduct)
         summary.ticketDetails("Reisende").should("contain", "1 Voksen")
         summary.ticketDetails("Sone").should("contain", "Reise i 1 sone (A)")
         summary.ticketDetails("Gyldig fra").should("contain", "Kjøpstidspunkt")
-        summary.ticketDetails("Gyldig til").should("contain", getFutureDate(30))
-        summary.price().should("contain", "890,00")
+        summary.ticketDetails("Gyldig til").should("contain", getFutureDate(defaultPeriodProductValidity))
+        summary.price().should("contain", defaultPeriodProductPrice)
     })
 
     it('valid to date in summary should reflect the product', () => {
@@ -242,7 +250,12 @@ describe('period ticket purchase', () => {
 
     it('changing zones should update the offer and summary', () => {
         let currentOffer = 890
+        const periodProd = '30-dagersbillett'
         const arrZone = 'B1'
+
+        //Init change
+        products.set(periodProd)
+        cy.wait("@zones")
 
         //Change
         zone.arrivalZone().select(arrZone)

--- a/e2e-tests/cypress/integration/tests/periodtickets.e2e_spec.js
+++ b/e2e-tests/cypress/integration/tests/periodtickets.e2e_spec.js
@@ -203,16 +203,7 @@ describe('period ticket purchase', () => {
     });
 
     it('valid to date in summary should reflect the product', () => {
-        // 30
-        products.set('30-dagersbillett');
-        newTicket.goToSummary();
-        summary.ticketDetails('Periode').should('contain', '30-dagersbillett');
-        summary
-            .ticketDetails('Gyldig til')
-            .should('contain', getFutureDate(30));
-
         // 180
-        summary.back();
         products.set('180-dagersbillett');
         cy.wait('@zones');
         newTicket.goToSummary();
@@ -220,6 +211,15 @@ describe('period ticket purchase', () => {
         summary
             .ticketDetails('Gyldig til')
             .should('contain', getFutureDate(180));
+
+        // 30
+        summary.back();
+        products.set('30-dagersbillett');
+        newTicket.goToSummary();
+        summary.ticketDetails('Periode').should('contain', '30-dagersbillett');
+        summary
+            .ticketDetails('Gyldig til')
+            .should('contain', getFutureDate(30));
 
         // 7
         summary.back();


### PR DESCRIPTION
Pga testing av nye billettprodukter så er det lagt til flere billettyper i staging, hvor 24-timersbilletten er satt som default per nå. Hvorvidt denne skal være default er usikkert, men endrer e2e-testene så de kjører fint.