### PR TITLE
fix: Not sca_exemption if payment type MasterCard

### DIFF
--- a/src/elm/Service/Ticket.elm
+++ b/src/elm/Service/Ticket.elm
@@ -284,11 +284,8 @@ encodePaymentSelection paymentSelection =
 isScaExemption : PaymentSelection -> Bool
 isScaExemption paymentSelection =
     case paymentSelection of
-        NonRecurring PaymentType.Vipps ->
-            False
-
         _ ->
-            True
+            False
 
 
 recurringPaymentDecoder : Decoder RecurringPayment


### PR DESCRIPTION
The SCA exemption flow is not working as intented when paying with
MasterCard in production.