### PR TITLE
Trigger onboarding if profile document doesn't have an id

### DIFF
--- a/src/static/index.js
+++ b/src/static/index.js
@@ -252,7 +252,7 @@ async function fetchAuthInfo(user, stopOnboarding) {
                 .onSnapshot((doc) => {
                     const profile = doc.data();
 
-                    if (!profile) {
+                    if (!profile || !profile.id) {
                         onboardingUser = user;
                         app.ports.onboardingStart.send([
                             idToken.token,


### PR DESCRIPTION
Closes #502 

The problem is that due to `securityLevel` existing as a field, `doc.data()` will not be `undefined` or an empty object, and the onboarding will thus never start. As far as I can tell, `id` as a field is only added once onboarding has been completed, so we check that that field is set to a non-falsey value.